### PR TITLE
feat: Introduce simple Rust1.73 HTTP server

### DIFF
--- a/http-rust1.73/Dockerfile
+++ b/http-rust1.73/Dockerfile
@@ -1,0 +1,15 @@
+FROM --platform=linux/x86_64 rust:1.73.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./server.rs /src/server.rs
+
+RUN set -xe; \
+    rustc -o /server /src/server.rs
+
+FROM scratch
+
+COPY --from=build /server /server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/

--- a/http-rust1.73/Kraftfile
+++ b/http-rust1.73/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: index.unikraft.io/official/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]

--- a/http-rust1.73/README.md
+++ b/http-rust1.73/README.md
@@ -1,0 +1,15 @@
+# Simple Rust 1.73 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-rust1.73/server.rs
+++ b/http-rust1.73/server.rs
@@ -1,0 +1,50 @@
+// https://gist.github.com/mjohnsullivan/e5182707caf0a9dbdf2d
+// Updated example from http://rosettacode.org/wiki/Hello_world/Web_server#Rust
+// to work with Rust 1.0 beta
+
+use std::net::{TcpStream, TcpListener};
+use std::io::{Read, Write};
+use std::thread;
+
+
+fn handle_read(mut stream: &TcpStream) {
+    let mut buf = [0u8 ;4096];
+    match stream.read(&mut buf) {
+        Ok(_) => {
+            let req_str = String::from_utf8_lossy(&buf);
+            println!("{}", req_str);
+        },
+        Err(e) => println!("Unable to read stream: {}", e),
+    }
+}
+
+fn handle_write(mut stream: TcpStream) {
+    let response = b"HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n<html><body>Hello world</body></html>\r\n";
+    match stream.write(response) {
+        Ok(_) => println!("Response sent"),
+        Err(e) => println!("Failed sending response: {}", e),
+    }
+}
+
+fn handle_client(stream: TcpStream) {
+    handle_read(&stream);
+    handle_write(stream);
+}
+
+fn main() {
+    let listener = TcpListener::bind("0.0.0.0:8080").unwrap();
+    println!("Listening for connections on port {}", 8080);
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                thread::spawn(|| {
+                    handle_client(stream)
+                });
+            }
+            Err(e) => {
+                println!("Unable to connect: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce simple Rust1.73 simple HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: Rust filesystem, including toolchain and libraries
* `README.md`: document how to use
* `server.rs`: the simple HTTP server implementation