### PR TITLE
feat: Introduce simple C++ HTTP server

### DIFF
--- a/http-cpp/Dockerfile
+++ b/http-cpp/Dockerfile
@@ -1,0 +1,24 @@
+FROM --platform=linux/x86_64 gcc:13.2.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+    g++ \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.cpp
+
+FROM scratch
+
+# System / C++ libraries
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /usr/local/lib64/libgcc_s.so.1 /usr/local/lib64/libgcc_s.so.1
+COPY --from=build /usr/local/lib64/libstdc++.so.6 /usr/local/lib64/libstdc++.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server

--- a/http-cpp/Kraftfile
+++ b/http-cpp/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: index.unikraft.io/official/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/http-cpp/README.md
+++ b/http-cpp/README.md
@@ -1,0 +1,15 @@
+# Simple C++ HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, simply invoke:
+
+```
+kraft cloud deploy -p 443:8080 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-cpp/http_server.cpp
+++ b/http-cpp/http_server.cpp
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, Unikraft GmbH and the Unikraft Authors.
+ */
+
+#include <iostream>
+#include <cstring>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <errno.h>
+
+#define LISTEN_PORT 8080
+
+static std::string reply = "HTTP/1.1 200 OK\r\n" \
+			    "Content-Type: text/html\r\n" \
+			    "Content-Length: 14\r\n" \
+			    "Connection: close\r\n" \
+			    "\r\n" \
+			    "Hello, World!\n";
+
+#define BUFLEN 2048
+static char recvbuf[BUFLEN];
+
+int main(int argc __attribute__((unused)),
+	 char *argv[] __attribute__((unused)))
+{
+	int rc = 0;
+	int srv, client;
+	ssize_t n;
+	struct sockaddr_in srv_addr;
+
+	srv = socket(AF_INET, SOCK_STREAM, 0);
+	if (srv < 0) {
+		std::cerr << "Failed to create socket: " << errno << std::endl;
+		goto out;
+	}
+
+	srv_addr.sin_family = AF_INET;
+	srv_addr.sin_addr.s_addr = INADDR_ANY;
+	srv_addr.sin_port = htons(LISTEN_PORT);
+
+	rc = bind(srv, (struct sockaddr *) &srv_addr, sizeof(srv_addr));
+	if (rc < 0) {
+		std::cerr << "Failed to bind socket: " << errno << std::endl;
+		goto out;
+	}
+
+	/* Accept one simultaneous connection */
+	rc = listen(srv, 1);
+	if (rc < 0) {
+		std::cerr << "Failed to listen on socket: " << errno << std::endl;
+		goto out;
+	}
+
+	std::cout << "Listening on port " << LISTEN_PORT << std::endl;
+	while (1) {
+		client = accept(srv, NULL, 0);
+		if (client < 0) {
+			std::cerr << "Failed to accept incoming connection: " << errno << std::endl;
+			goto out;
+		}
+
+		/* Receive some bytes (ignore errors) */
+		read(client, recvbuf, BUFLEN);
+
+		/* Send reply */
+		n = write(client, reply.c_str(), reply.length());
+		if (n < 0)
+			std::cerr << "Failed to send reply" << std::endl;
+		else
+			std::cout << "Sent a reply" << std::endl;
+
+		/* Close connection */
+		close(client);
+	}
+
+out:
+	return rc;
+}


### PR DESCRIPTION
Introduce simple C++ HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `README.md`: document how to use
* `http_server.cpp`: the simple HTTP server implementation