### PR TITLE
feat: Introduce simple C++ Boost HTTP server

### DIFF
--- a/http-cpp-boost/Dockerfile
+++ b/http-cpp-boost/Dockerfile
@@ -1,0 +1,30 @@
+FROM --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe ; \
+	apt -yqq update ; \
+	apt -yqq install build-essential ; \
+	apt -yqq install libboost-all-dev
+
+WORKDIR /src
+
+COPY ./http_server.cpp /src/http_server.cpp
+
+RUN set -xe; \
+    g++ \
+	-Wall -Wextra \
+	-fPIC -pie \
+	-o /http_server http_server.cpp \
+	-lboost_system -lboost_thread -lpthread
+
+FROM scratch
+
+# System / C++ libraries
+COPY --from=build /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0 /lib/x86_64-linux-gnu/libboost_thread.so.1.74.0
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+# C++ HTTP server
+COPY --from=build /http_server /http_server

--- a/http-cpp-boost/Kraftfile
+++ b/http-cpp-boost/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/http_server"]

--- a/http-cpp-boost/README.md
+++ b/http-cpp-boost/README.md
@@ -1,0 +1,15 @@
+# Simple C++ Boost HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-cpp-boost/http_server.cpp
+++ b/http-cpp-boost/http_server.cpp
@@ -1,0 +1,114 @@
+/**
+ *  Compile with: g++ async_http_server.cpp -o async_http_server -lboost_system -lboost_thread -lpthread
+ *
+ *  https://gist.github.com/danilogr/990efa4ab3b5bce29b883b931ac55507
+ */
+
+#include <iostream>
+#include <ostream>
+#include <istream>
+#include <ctime>
+#include <string>
+#include <functional>
+#include <boost/asio.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/enable_shared_from_this.hpp>
+#include <boost/thread.hpp>
+
+using boost::asio::ip::tcp;
+
+class HttpServer; // forward declaration
+
+class Request : public boost::enable_shared_from_this<Request>
+{
+	// member variables
+	HttpServer& server;
+	boost::asio::streambuf request;
+	boost::asio::streambuf response;
+
+	void afterRead(const boost::system::error_code& ec, std::size_t bytes_transferred)
+	{
+		// done reading, writes answer (yes, we ignore the request);
+		std::ostream res_stream(&response);
+
+		boost::system::error_code err;
+		res_stream << "HTTP/1.0 200 OK\r\n"
+			<< "Content-Type: text/html; charset=UTF-8\r\n"
+			<< "Content-Length: 14\r\n"
+			<< "\r\n"
+			<< "Hello, World!\n" << "\r\n";
+		boost::asio::async_write(*socket, response, boost::bind(&Request::afterWrite, shared_from_this(), err, bytes_transferred));
+	}
+
+	void afterWrite(const boost::system::error_code& ec, std::size_t bytes_transferred)
+	{
+		// done writing, closing connection
+		socket->close();
+	}
+
+	public:
+
+	boost::shared_ptr<tcp::socket> socket;
+	Request(HttpServer& server);
+	void answer()
+	{
+		if (!socket) return;
+
+		// reads request till the end
+		boost::system::error_code err;
+		boost::asio::async_read_until(*socket, request, "\r\n\r\n",
+				boost::bind(&Request::afterRead, shared_from_this(), err, 0));
+	}
+};
+
+
+class HttpServer
+{
+	public:
+
+		HttpServer(unsigned int port) : acceptor(io_service, tcp::endpoint(tcp::v4(), port)) {}
+		~HttpServer() { if (sThread) sThread->join(); }
+
+		void Run()
+		{
+			sThread.reset(new boost::thread(boost::bind(&HttpServer::thread_main, this)));
+		}
+
+		boost::asio::io_service io_service;
+
+	private:
+		tcp::acceptor acceptor;
+		boost::shared_ptr<boost::thread> sThread;
+
+		void thread_main()
+		{
+			// adds some work to the io_service
+			start_accept();
+			io_service.run();
+		}
+		void start_accept()
+		{
+			boost::system::error_code err;
+			boost::shared_ptr<Request> req (new Request(*this));
+			acceptor.async_accept(*req->socket,
+					boost::bind(&HttpServer::handle_accept, this, req, err));
+		}
+
+		void handle_accept(boost::shared_ptr<Request> req, const boost::system::error_code& error)
+		{
+			if (!error) { req->answer(); }
+			start_accept();
+		}
+};
+
+Request::Request(HttpServer& server): server(server)
+{
+	socket.reset(new tcp::socket(server.io_service));
+}
+
+
+int main()
+{
+	HttpServer server(8080);
+	server.Run();
+}


### PR DESCRIPTION
Introduce simple C++ Boost HTTP server (i.e. using `libboost`) to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `README.md`: document how to use
* `http_server.cpp`: the simple HTTP server implementation