### PR TITLE
feat: Introduce simple Node21 HTTP server

### DIFF
--- a/http-node21/Dockerfile
+++ b/http-node21/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# Simple Node HTTP server
+COPY ./server.js /usr/src/server.js

--- a/http-node21/Kraftfile
+++ b/http-node21/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: node:21
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/http-node21/README.md
+++ b/http-node21/README.md
@@ -1,0 +1,15 @@
+# Simple Node21 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 -M 256 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-node21/server.js
+++ b/http-node21/server.js
@@ -1,0 +1,16 @@
+const http = require('http'); // Loads the http module
+
+http.createServer((request, response) => {
+
+    // 1. Tell the browser everything is OK (Status code 200), and the data is in plain text
+    response.writeHead(200, {
+        'Content-Type': 'text/plain'
+    });
+
+    // 2. Write the announced text to the body of the page
+    response.write('Hello, World!\n');
+
+    // 3. Tell the server that all of the response headers and body have been sent
+    response.end();
+
+}).listen(8080); // 4. Tells the server what port to be on


### PR DESCRIPTION
Introduce simple Node21 HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: Node filesystem, including binaries and libraries
* `README.md`: document how to use
* `server.py`: the HTTP server implementation