### PR TITLE
feat: Introduce simple Perl5.38 HTTP server

### DIFF
--- a/http-perl5.38/Dockerfile
+++ b/http-perl5.38/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# Simple Perl HTTP server
+COPY ./server.pl /usr/src/server.pl

--- a/http-perl5.38/Kraftfile
+++ b/http-perl5.38/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: perl:5.38
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/perl", "/usr/src/server.pl"]

--- a/http-perl5.38/README.md
+++ b/http-perl5.38/README.md
@@ -1,0 +1,15 @@
+# Simple Perl5.38 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 -M 512 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-perl5.38/server.pl
+++ b/http-perl5.38/server.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+use HTTP::Daemon;
+use HTTP::Status;
+use HTTP::Response;
+
+my $daemon = HTTP::Daemon->new(
+	LocalAddr => '0.0.0.0',
+	LocalPort => 8080,
+) or die;
+
+while (my $client_connection = $daemon->accept) {
+	my $request = $client_connection->get_request;
+	my $response = HTTP::Response->new(200);
+	$response->content("Hello, World!\n");
+	$client_connection->send_response($response);
+}


### PR DESCRIPTION
Introduce simple Perl5.38 HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: Perl filesystem, including binaries and libraries
* `README.md`: document how to use
* `server.py`: the HTTP server implementation