### PR TITLE
feat: Introduce simple PHP8.2 HTTP server

### DIFF
--- a/http-php8.2/Dockerfile
+++ b/http-php8.2/Dockerfile
@@ -1,0 +1,65 @@
+FROM --platform=linux/x86_64 php:8.2-cli AS build
+
+RUN docker-php-ext-install sockets
+
+FROM scratch
+
+# PHP binary
+COPY --from=build /usr/local/bin/php /usr/local/bin/php
+
+# PHP libraries
+COPY --from=build /usr/local/lib/libphp.so /usr/local/lib/libphp.so
+COPY --from=build /usr/local/lib/php /usr/local/lib/php
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libreadline.so.8 /lib/x86_64-linux-gnu/libreadline.so.8
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libxml2.so.2 /lib/x86_64-linux-gnu/libxml2.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libsqlite3.so.0 /lib/x86_64-linux-gnu/libsqlite3.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libcurl.so.4 /lib/x86_64-linux-gnu/libcurl.so.4
+COPY --from=build /lib/x86_64-linux-gnu/libonig.so.5 /lib/x86_64-linux-gnu/libonig.so.5
+COPY --from=build /lib/x86_64-linux-gnu/libargon2.so.1 /lib/x86_64-linux-gnu/libargon2.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libicuuc.so.72 /lib/x86_64-linux-gnu/libicuuc.so.72
+COPY --from=build /lib/x86_64-linux-gnu/liblzma.so.5 /lib/x86_64-linux-gnu/liblzma.so.5
+COPY --from=build /lib/x86_64-linux-gnu/libnghttp2.so.14 /lib/x86_64-linux-gnu/libnghttp2.so.14
+COPY --from=build /lib/x86_64-linux-gnu/libidn2.so.0 /lib/x86_64-linux-gnu/libidn2.so.0
+COPY --from=build /lib/x86_64-linux-gnu/librtmp.so.1 /lib/x86_64-linux-gnu/librtmp.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libssh2.so.1 /lib/x86_64-linux-gnu/libssh2.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libpsl.so.5 /lib/x86_64-linux-gnu/libpsl.so.5
+COPY --from=build /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 /lib/x86_64-linux-gnu/libgssapi_krb5.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libldap-2.5.so.0 /lib/x86_64-linux-gnu/libldap-2.5.so.0
+COPY --from=build /lib/x86_64-linux-gnu/liblber-2.5.so.0 /lib/x86_64-linux-gnu/liblber-2.5.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu/libzstd.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlidec.so.1 /lib/x86_64-linux-gnu/libbrotlidec.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libicudata.so.72 /lib/x86_64-linux-gnu/libicudata.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libunistring.so.2 /lib/x86_64-linux-gnu/libunistring.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libgnutls.so.30 /lib/x86_64-linux-gnu/libgnutls.so.30
+COPY --from=build /lib/x86_64-linux-gnu/libhogweed.so.6 /lib/x86_64-linux-gnu/libhogweed.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libnettle.so.8 /lib/x86_64-linux-gnu/libnettle.so.8
+COPY --from=build /lib/x86_64-linux-gnu/libgmp.so.10 /lib/x86_64-linux-gnu/libgmp.so.10
+COPY --from=build /lib/x86_64-linux-gnu/libkrb5.so.3 /lib/x86_64-linux-gnu/libkrb5.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libk5crypto.so.3 /lib/x86_64-linux-gnu/libk5crypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libcom_err.so.2 /lib/x86_64-linux-gnu/libcom_err.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libkrb5support.so.0 /lib/x86_64-linux-gnu/libkrb5support.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libsasl2.so.2 /lib/x86_64-linux-gnu/libsasl2.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libbrotlicommon.so.1 /lib/x86_64-linux-gnu/libbrotlicommon.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libp11-kit.so.0 /lib/x86_64-linux-gnu/libp11-kit.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libtasn1.so.6 /lib/x86_64-linux-gnu/libtasn1.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libkeyutils.so.1 /lib/x86_64-linux-gnu/libkeyutils.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libresolv.so.2 /lib/x86_64-linux-gnu/libresolv.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libffi.so.8 /lib/x86_64-linux-gnu/libffi.so.8
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# PHP configuration
+COPY ./php.ini /usr/local/etc/php/php.ini
+
+# Simple PHP HTTP server
+COPY ./http_server.php /http_server.php

--- a/http-php8.2/Kraftfile
+++ b/http-php8.2/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: index.unikraft.io/official/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/php /http_server.php"]

--- a/http-php8.2/README.md
+++ b/http-php8.2/README.md
@@ -1,0 +1,15 @@
+# Simple PHP8.2 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-php8.2/http_server.php
+++ b/http-php8.2/http_server.php
@@ -1,0 +1,45 @@
+#!/usr/local/bin/php -q
+<?php
+error_reporting(E_ALL);
+
+/* Allow the script to hang around waiting for connections. */
+set_time_limit(0);
+
+/* Turn on implicit output flushing so we see what we're getting
+ * as it comes in. */
+ob_implicit_flush();
+
+$address = '0.0.0.0';
+$port = 8080;
+
+if (($sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP)) === false) {
+    echo "socket_create() failed: reason: " . socket_strerror(socket_last_error()) . "\n";
+}
+
+if (socket_bind($sock, $address, $port) === false) {
+    echo "socket_bind() failed: reason: " . socket_strerror(socket_last_error($sock)) . "\n";
+}
+
+if (socket_listen($sock, 5) === false) {
+    echo "socket_listen() failed: reason: " . socket_strerror(socket_last_error($sock)) . "\n";
+}
+
+do {
+    if (($msgsock = socket_accept($sock)) === false) {
+        echo "socket_accept() failed: reason: " . socket_strerror(socket_last_error($sock)) . "\n";
+        break;
+    }
+    /* Send instructions. */
+    $msg = "HTTP/1.1 200 OK\r\n" .
+        "Content-Type: text/html\r\n" .
+        "Content-Length: 14\r\n" .
+        "Connection: close\r\n" .
+        "\r\n" .
+        "Hello, World!\n";
+    socket_write($msgsock, $msg, strlen($msg));
+
+    socket_close($msgsock);
+} while (true);
+
+socket_close($sock);
+?>

--- a/http-php8.2/php.ini
+++ b/http-php8.2/php.ini
@@ -1,0 +1,3 @@
+[PHP]
+
+extension=sockets


### PR DESCRIPTION
Introduce simple PHP8.2 HTTP server to be deployed on KraftCloud.  It uses binary compatibility mode (i.e. the `base` image).
    
Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: PHP filesystem, including binaries and libraries
* `README.md`: document how to use
* `server.py`: the HTTP server implementation