### PR TITLE
feat: Introduce simple Python3.12 HTTP server

### DIFF
--- a/http-python3.12/Dockerfile
+++ b/http-python3.12/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# Python HTTP server
+COPY ./server.py /src/server.py

--- a/http-python3.12/Kraftfile
+++ b/http-python3.12/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: python:3.12
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/python", "/src/server.py"]

--- a/http-python3.12/README.md
+++ b/http-python3.12/README.md
@@ -1,0 +1,15 @@
+# Simple Python 3.12 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 -M 512 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-python3.12/server.py
+++ b/http-python3.12/server.py
@@ -1,0 +1,31 @@
+import argparse
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class MyServer(BaseHTTPRequestHandler):
+  def do_GET(self):
+    self.send_response(200)
+    self.send_header("Content-type", "text/html")
+    self.end_headers()
+    self.wfile.write(bytes("Hello, World!\n", "utf-8"))
+
+def main(args):
+  server = HTTPServer((args.host, args.port), MyServer)
+
+  print("starting server at %s:%s" % (args.host, args.port))
+
+  try:
+    server.serve_forever()
+
+  except KeyboardInterrupt:
+    pass
+
+  print("server stopped")
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--host", type=str, default="0.0.0.0")
+  parser.add_argument("--port", type=int, default=8080)
+  return parser.parse_args()
+
+if __name__ == "__main__":
+  main(parse_args())


### PR DESCRIPTION
Introduce simple Python3.12 HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: Python filesystem, including binaries and libraries
* `README.md`: document how to use
* `server.py`: the simple HTTP server implementation