### PR TITLE
feat: Introduce simple Ruby3.2 HTTP server

### DIFF
--- a/http-ruby3.2/Dockerfile
+++ b/http-ruby3.2/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# Simple Ruby HTTP server
+COPY ./server.rb /src/server.rb

--- a/http-ruby3.2/Kraftfile
+++ b/http-ruby3.2/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: ruby:3.2
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/ruby", "/src/server.rb"]

--- a/http-ruby3.2/README.md
+++ b/http-ruby3.2/README.md
@@ -1,0 +1,15 @@
+# Simple Ruby3.2 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 -M 256 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-ruby3.2/server.rb
+++ b/http-ruby3.2/server.rb
@@ -1,0 +1,20 @@
+# https://dev.to/leandronsp/web-basics-a-simple-http-server-in-ruby-2jj4
+
+require 'socket'
+
+socket = TCPServer.new(8080)
+
+loop do
+  client = socket.accept
+
+  request = client.gets
+
+  response = "HTTP/1.1 200 OK\r\n" \
+    "Content-type: text/html\r\n" \
+    "Connection: close\r\n" \
+    "\r\n" \
+    "Hello, World!"
+  client.puts(response)
+
+  client.close
+end


### PR DESCRIPTION
Introduce simple Ruby3.2 HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: Ruby filesystem, including binaries and libraries
* `README.md`: document how to use
* `server.py`: the HTTP server implementation