### PR TITLE
feat: Introduce Lua5.1 HTTP server

### DIFF
--- a/http-lua5.1/Dockerfile
+++ b/http-lua5.1/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+
+# Lua server
+COPY ./http_server.lua /http_server.lua

--- a/http-lua5.1/Kraftfile
+++ b/http-lua5.1/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: lua:5.1
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/lua", "/http_server.lua"]

--- a/http-lua5.1/README.md
+++ b/http-lua5.1/README.md
@@ -1,0 +1,15 @@
+# Lua 5.1.5 HTTP Web Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-lua5.1/http_server.lua
+++ b/http-lua5.1/http_server.lua
@@ -1,0 +1,64 @@
+#!/usr/bin/env lua
+--[[
+A simple HTTP server
+
+If a request is not a HEAD method, then reply with "Hello world!"
+
+Usage: lua examples/server_hello.lua [<port>]
+]]
+
+-- https://github.com/daurnimator/lua-http/blob/master/examples/server_hello.lua
+
+local port = arg[1] or 8080
+
+local http_server = require "http.server"
+local http_headers = require "http.headers"
+
+local function reply(myserver, stream) -- luacheck: ignore 212
+	-- Read in headers
+	local req_headers = assert(stream:get_headers())
+	local req_method = req_headers:get ":method"
+
+	-- Log request to stdout
+	assert(io.stdout:write(string.format('[%s] "%s %s HTTP/%g"  "%s" "%s"\n',
+		os.date("%d/%b/%Y:%H:%M:%S %z"),
+		req_method or "",
+		req_headers:get(":path") or "",
+		stream.connection.version,
+		req_headers:get("referer") or "-",
+		req_headers:get("user-agent") or "-"
+	)))
+
+	-- Build response headers
+	local res_headers = http_headers.new()
+	res_headers:append(":status", "200")
+	res_headers:append("content-type", "text/plain")
+	-- Send headers to client; end the stream immediately if this was a HEAD request
+	assert(stream:write_headers(res_headers, req_method == "HEAD"))
+	if req_method ~= "HEAD" then
+		-- Send body, ending the stream
+		assert(stream:write_chunk("Hello, World!\n", true))
+	end
+end
+
+local myserver = assert(http_server.listen {
+	host = "0.0.0.0";
+	port = port;
+	onstream = reply;
+	onerror = function(myserver, context, op, err, errno) -- luacheck: ignore 212
+		local msg = op .. " on " .. tostring(context) .. " failed"
+		if err then
+			msg = msg .. ": " .. tostring(err)
+		end
+		assert(io.stderr:write(msg, "\n"))
+	end;
+})
+
+-- Manually call :listen() so that we are bound before calling :localname()
+assert(myserver:listen())
+do
+	local bound_port = select(3, myserver:localname())
+	assert(io.stderr:write(string.format("Now listening on port %d\n", bound_port)))
+end
+-- Start the main server loop
+assert(myserver:loop())


### PR DESCRIPTION
Introduce Lua5.1 HTTP server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `lua:5.1` image
* `Dockerfile`: the application filesystem, comprised solely of the `http_server.lua` script
* `README.md`: document how to use
* `http_server.lua`: the HTTP server implementation