### PR TITLE
feat: Introduce epoll-based echo-reply server

### DIFF
--- a/http-c-epoll/Dockerfile
+++ b/http-c-epoll/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcc:13.2-bookworm AS build
+
+COPY /src /src
+
+WORKDIR /src
+RUN make
+
+FROM scratch
+
+COPY --from=build /src/epoll_echo_server /server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/http-c-epoll/Kraftfile
+++ b/http-c-epoll/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]

--- a/http-c-epoll/README.md
+++ b/http-c-epoll/README.md
@@ -1,0 +1,24 @@
+# Simple epoll-based Echo Reply C Server
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, simply invoke:
+
+```console
+kraft cloud deploy -p 42424:42424/tls .
+```
+
+To use the application, connect to the remote URL (provided by the above command):
+
+```console
+openssl s_client -connect <url>:42424
+```
+
+Replace `<url>` with the URL provided by the `kraft cloud deploy` command.
+Send out messages to be replied by the epoll-based server.
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-c-epoll/src/.gitignore
+++ b/http-c-epoll/src/.gitignore
@@ -1,0 +1,2 @@
+/epoll_echo_server
+*.o

--- a/http-c-epoll/src/Makefile
+++ b/http-c-epoll/src/Makefile
@@ -1,0 +1,20 @@
+CPPFLAGS = -I.
+CFLAGS = -Wall -Wextra -fPIC
+LDFLAGS = -pie
+
+.PHONY: all clean
+
+all: epoll_echo_server
+
+epoll_echo_server: epoll_echo_server.o utils/sock/sock_util.o utils/log/log.o
+
+epoll_echo_server.o: epoll_echo_server.c utils/sock/sock_util.h utils/log/log.h utils/utils.h
+
+utils/sock/sock_util.o: utils/sock/sock_util.c utils/sock/sock_util.h
+
+utils/log/log.o: utils/log/log.c utils/log/log.h
+
+clean::
+	-rm -f utils/sock/sock_util.o utils/log/log.o
+	-rm -f epoll_echo_server.o epoll_echo_server
+	-rm -f *~

--- a/http-c-epoll/src/epoll_echo_server.c
+++ b/http-c-epoll/src/epoll_echo_server.c
@@ -1,0 +1,283 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * epoll-based echo server. Uses epoll(7) to multiplex connections.
+ *
+ * TODO:
+ *  - block data receiving when receive buffer is full (use circular buffers)
+ *  - do not copy receive buffer into send buffer when send buffer data is
+ *      still valid
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "utils/utils.h"
+#include "utils/log/log.h"
+#include "utils/sock/sock_util.h"
+#include "./w_epoll.h"
+
+#define ECHO_LISTEN_PORT		42424
+
+
+/* server socket file descriptor */
+static int listenfd;
+
+/* epoll file descriptor */
+static int epollfd;
+
+enum connection_state {
+	STATE_DATA_RECEIVED,
+	STATE_DATA_SENT,
+	STATE_CONNECTION_CLOSED
+};
+
+/* structure acting as a connection handler */
+struct connection {
+	int sockfd;
+	/* buffers used for receiving messages and then echoing them back */
+	char recv_buffer[BUFSIZ];
+	size_t recv_len;
+	char send_buffer[BUFSIZ];
+	size_t send_len;
+	enum connection_state state;
+};
+
+/*
+ * Initialize connection structure on given socket.
+ */
+
+static struct connection *connection_create(int sockfd)
+{
+	struct connection *conn = malloc(sizeof(*conn));
+
+	DIE(conn == NULL, "malloc");
+
+	conn->sockfd = sockfd;
+	memset(conn->recv_buffer, 0, BUFSIZ);
+	memset(conn->send_buffer, 0, BUFSIZ);
+
+	return conn;
+}
+
+/*
+ * Copy receive buffer to send buffer (echo).
+ */
+
+static void connection_copy_buffers(struct connection *conn)
+{
+	conn->send_len = conn->recv_len;
+	memcpy(conn->send_buffer, conn->recv_buffer, conn->send_len);
+}
+
+/*
+ * Remove connection handler.
+ */
+
+static void connection_remove(struct connection *conn)
+{
+	close(conn->sockfd);
+	conn->state = STATE_CONNECTION_CLOSED;
+	free(conn);
+}
+
+/*
+ * Handle a new connection request on the server socket.
+ */
+
+static void handle_new_connection(void)
+{
+	static int sockfd;
+	socklen_t addrlen = sizeof(struct sockaddr_in);
+	struct sockaddr_in addr;
+	struct connection *conn;
+	int rc;
+
+	/* accept new connection */
+	sockfd = accept(listenfd, (SSA *) &addr, &addrlen);
+	DIE(sockfd < 0, "accept");
+
+	log_debug("Accepted connection from: %s:%d",
+			inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
+
+	/* instantiate new connection handler */
+	conn = connection_create(sockfd);
+
+	/* add socket to epoll */
+	rc = w_epoll_add_ptr_in(epollfd, sockfd, conn);
+	DIE(rc < 0, "w_epoll_add_in");
+}
+
+/*
+ * Receive message on socket.
+ * Store message in recv_buffer in struct connection.
+ */
+
+static enum connection_state receive_message(struct connection *conn)
+{
+	ssize_t bytes_recv;
+	int rc;
+	char abuffer[64];
+
+	rc = get_peer_address(conn->sockfd, abuffer, 64);
+	if (rc < 0) {
+		log_error("get_peer_address");
+		goto remove_connection;
+	}
+
+	bytes_recv = recv(conn->sockfd, conn->recv_buffer, BUFSIZ, 0);
+	if (bytes_recv < 0) {		/* error in communication */
+		log_error("Error in communication from: %s", abuffer);
+		goto remove_connection;
+	}
+	if (bytes_recv == 0) {		/* connection closed */
+		log_info("Connection closed from: %s", abuffer);
+		goto remove_connection;
+	}
+
+	log_debug("Received message from: %s", abuffer);
+	log_debug("--%s--", conn->recv_buffer);
+
+	conn->recv_len = bytes_recv;
+	conn->state = STATE_DATA_RECEIVED;
+
+	return STATE_DATA_RECEIVED;
+
+remove_connection:
+	rc = w_epoll_remove_ptr(epollfd, conn->sockfd, conn);
+	DIE(rc < 0, "w_epoll_remove_ptr");
+
+	/* remove current connection */
+	connection_remove(conn);
+
+	return STATE_CONNECTION_CLOSED;
+}
+
+/*
+ * Send message on socket.
+ * Store message in send_buffer in struct connection.
+ */
+
+static enum connection_state send_message(struct connection *conn)
+{
+	ssize_t bytes_sent;
+	int rc;
+	char abuffer[64];
+
+	rc = get_peer_address(conn->sockfd, abuffer, 64);
+	if (rc < 0) {
+		log_error("get_peer_address");
+		goto remove_connection;
+	}
+
+	bytes_sent = send(conn->sockfd, conn->send_buffer, conn->send_len, 0);
+	if (bytes_sent < 0) {		/* error in communication */
+		log_error("Error in communication to %s", abuffer);
+		goto remove_connection;
+	}
+	if (bytes_sent == 0) {		/* connection closed */
+		log_info("Connection closed to %s", abuffer);
+		goto remove_connection;
+	}
+
+	log_debug("Sending message to %s", abuffer);
+	log_debug("--%s--", conn->send_buffer);
+
+	/* all done - remove out notification */
+	rc = w_epoll_update_ptr_in(epollfd, conn->sockfd, conn);
+	DIE(rc < 0, "w_epoll_update_ptr_in");
+
+	conn->state = STATE_DATA_SENT;
+
+	return STATE_DATA_SENT;
+
+remove_connection:
+	rc = w_epoll_remove_ptr(epollfd, conn->sockfd, conn);
+	DIE(rc < 0, "w_epoll_remove_ptr");
+
+	/* remove current connection */
+	connection_remove(conn);
+
+	return STATE_CONNECTION_CLOSED;
+}
+
+/*
+ * Handle a client request on a client connection.
+ */
+
+static void handle_client_request(struct connection *conn)
+{
+	int rc;
+	enum connection_state ret_state;
+
+	ret_state = receive_message(conn);
+	if (ret_state == STATE_CONNECTION_CLOSED)
+		return;
+
+	connection_copy_buffers(conn);
+
+	/* add socket to epoll for out events */
+	rc = w_epoll_update_ptr_inout(epollfd, conn->sockfd, conn);
+	DIE(rc < 0, "w_epoll_add_ptr_inout");
+}
+
+int main(void)
+{
+	int rc;
+
+	/* init multiplexing */
+	epollfd = w_epoll_create();
+	DIE(epollfd < 0, "w_epoll_create");
+
+	/* create server socket */
+	listenfd = tcp_create_listener(ECHO_LISTEN_PORT,
+		DEFAULT_LISTEN_BACKLOG);
+	DIE(listenfd < 0, "tcp_create_listener");
+
+	rc = w_epoll_add_fd_in(epollfd, listenfd);
+	DIE(rc < 0, "w_epoll_add_fd_in");
+
+	log_info("Server waiting for connections on port %d",
+			ECHO_LISTEN_PORT);
+
+	/* server main loop */
+	while (1) {
+		struct epoll_event rev;
+
+		/* wait for events */
+		rc = w_epoll_wait_infinite(epollfd, &rev);
+		DIE(rc < 0, "w_epoll_wait_infinite");
+
+		/*
+		 * switch event types; consider
+		 *   - new connection requests (on server socket)
+		 *   - socket communication (on connection sockets)
+		 */
+
+		if (rev.data.fd == listenfd) {
+			log_debug("New connection");
+			if (rev.events & EPOLLIN)
+				handle_new_connection();
+		} else {
+			if (rev.events & EPOLLIN) {
+				log_debug("New message");
+				handle_client_request(rev.data.ptr);
+			}
+			if (rev.events & EPOLLOUT) {
+				log_debug("Ready to send message");
+				send_message(rev.data.ptr);
+			}
+		}
+	}
+
+	return 0;
+}

--- a/http-c-epoll/src/utils/log/log.c
+++ b/http-c-epoll/src/utils/log/log.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2020 rxi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+/* Github link: https://github.com/rxi/log.c */
+
+#include "log.h"
+
+#define MAX_CALLBACKS 32
+
+typedef struct {
+  log_LogFn fn;
+  void *udata;
+  int level;
+} Callback;
+
+static struct {
+  void *udata;
+  log_LockFn lock;
+  int level;
+  bool quiet;
+  Callback callbacks[MAX_CALLBACKS];
+} L;
+
+
+static const char *level_strings[] = {
+  "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
+};
+
+#ifdef LOG_USE_COLOR
+static const char *level_colors[] = {
+  "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"
+};
+#endif
+
+
+static void stdout_callback(log_Event *ev) {
+  char buf[16];
+  buf[strftime(buf, sizeof(buf), "%H:%M:%S", ev->time)] = '\0';
+#ifdef LOG_USE_COLOR
+  fprintf(
+    ev->udata, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
+    buf, level_colors[ev->level], level_strings[ev->level],
+    ev->file, ev->line);
+#else
+  fprintf(
+    ev->udata, "%s %-5s %s:%d: ",
+    buf, level_strings[ev->level], ev->file, ev->line);
+#endif
+  vfprintf(ev->udata, ev->fmt, ev->ap);
+  fprintf(ev->udata, "\n");
+  fflush(ev->udata);
+}
+
+
+static void file_callback(log_Event *ev) {
+  char buf[64];
+  buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", ev->time)] = '\0';
+  fprintf(
+    ev->udata, "%s %-5s %s:%d: ",
+    buf, level_strings[ev->level], ev->file, ev->line);
+  vfprintf(ev->udata, ev->fmt, ev->ap);
+  fprintf(ev->udata, "\n");
+  fflush(ev->udata);
+}
+
+
+static void lock(void)   {
+  if (L.lock) { L.lock(true, L.udata); }
+}
+
+
+static void unlock(void) {
+  if (L.lock) { L.lock(false, L.udata); }
+}
+
+
+const char* log_level_string(int level) {
+  return level_strings[level];
+}
+
+
+void log_set_lock(log_LockFn fn, void *udata) {
+  L.lock = fn;
+  L.udata = udata;
+}
+
+
+void log_set_level(int level) {
+  L.level = level;
+}
+
+
+void log_set_quiet(bool enable) {
+  L.quiet = enable;
+}
+
+
+int log_add_callback(log_LogFn fn, void *udata, int level) {
+  for (int i = 0; i < MAX_CALLBACKS; i++) {
+    if (!L.callbacks[i].fn) {
+      L.callbacks[i] = (Callback) { fn, udata, level };
+      return 0;
+    }
+  }
+  return -1;
+}
+
+
+int log_add_fp(FILE *fp, int level) {
+  return log_add_callback(file_callback, fp, level);
+}
+
+
+static void init_event(log_Event *ev, void *udata) {
+  if (!ev->time) {
+    time_t t = time(NULL);
+    ev->time = localtime(&t);
+  }
+  ev->udata = udata;
+}
+
+
+void log_log(int level, const char *file, int line, const char *fmt, ...) {
+  log_Event ev = {
+    .fmt   = fmt,
+    .file  = file,
+    .line  = line,
+    .level = level,
+  };
+
+  lock();
+
+  if (!L.quiet && level >= L.level) {
+    init_event(&ev, stderr);
+    va_start(ev.ap, fmt);
+    stdout_callback(&ev);
+    va_end(ev.ap);
+  }
+
+  for (int i = 0; i < MAX_CALLBACKS && L.callbacks[i].fn; i++) {
+    Callback *cb = &L.callbacks[i];
+    if (level >= cb->level) {
+      init_event(&ev, cb->udata);
+      va_start(ev.ap, fmt);
+      cb->fn(&ev);
+      va_end(ev.ap);
+    }
+  }
+
+  unlock();
+}

--- a/http-c-epoll/src/utils/log/log.h
+++ b/http-c-epoll/src/utils/log/log.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2020 rxi
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the MIT license. See `log.c` for details.
+ */
+
+/* Github link: https://github.com/rxi/log.c */
+
+#ifndef LOG_H
+#define LOG_H
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define LOG_VERSION "0.1.0"
+
+typedef struct {
+  va_list ap;
+  const char *fmt;
+  const char *file;
+  struct tm *time;
+  void *udata;
+  int line;
+  int level;
+} log_Event;
+
+typedef void (*log_LogFn)(log_Event *ev);
+typedef void (*log_LockFn)(bool lock, void *udata);
+
+enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
+
+#define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+#define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+#define log_info(...)  log_log(LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
+#define log_warn(...)  log_log(LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
+#define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
+#define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+
+const char* log_level_string(int level);
+void log_set_lock(log_LockFn fn, void *udata);
+void log_set_level(int level);
+void log_set_quiet(bool enable);
+int log_add_callback(log_LogFn fn, void *udata, int level);
+int log_add_fp(FILE *fp, int level);
+
+void log_log(int level, const char *file, int line, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LOG_H */

--- a/http-c-epoll/src/utils/sock/sock_util.c
+++ b/http-c-epoll/src/utils/sock/sock_util.c
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Useful socket functions
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include "utils/utils.h"
+#include "utils/log/log.h"
+#include "utils/sock/sock_util.h"
+
+/*
+ * Connect to a TCP server identified by name (DNS name or dotted decimal
+ * string) and port.
+ */
+
+int tcp_connect_to_server(const char *name, unsigned short port)
+{
+	struct hostent *hent;
+	struct sockaddr_in server_addr;
+	int s;
+	int rc;
+
+	hent = gethostbyname(name);
+	DIE(hent == NULL, "gethostbyname");
+
+	s = socket(PF_INET, SOCK_STREAM, 0);
+	DIE(s < 0, "socket");
+
+	memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_port = htons(port);
+	memcpy(&server_addr.sin_addr.s_addr, hent->h_addr,
+			sizeof(server_addr.sin_addr.s_addr));
+
+	rc = connect(s, (struct sockaddr *) &server_addr, sizeof(server_addr));
+	DIE(rc < 0, "connect");
+
+	return s;
+}
+
+int tcp_close_connection(int sockfd)
+{
+	int rc;
+
+	rc = shutdown(sockfd, SHUT_RDWR);
+	DIE(rc < 0, "shutdown");
+
+	return close(sockfd);
+}
+
+/*
+ * Create a server socket.
+ */
+
+int tcp_create_listener(unsigned short port, int backlog)
+{
+	struct sockaddr_in address;
+	int listenfd;
+	int sock_opt;
+	int rc;
+
+	listenfd = socket(PF_INET, SOCK_STREAM, 0);
+	DIE(listenfd < 0, "socket");
+
+	sock_opt = 1;
+	rc = setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR,
+				&sock_opt, sizeof(int));
+	DIE(rc < 0, "setsockopt");
+
+	memset(&address, 0, sizeof(address));
+	address.sin_family = AF_INET;
+	address.sin_port = htons(port);
+	address.sin_addr.s_addr = INADDR_ANY;
+
+	rc = bind(listenfd, (SSA *) &address, sizeof(address));
+	DIE(rc < 0, "bind");
+
+	rc = listen(listenfd, backlog);
+	DIE(rc < 0, "listen");
+
+	return listenfd;
+}
+
+/*
+ * Use getpeername(2) to extract remote peer address. Fill buffer with
+ * address format IP_address:port (e.g. 192.168.0.1:22).
+ */
+
+int get_peer_address(int sockfd, char *buf, size_t len)
+{
+	struct sockaddr_in addr;
+	socklen_t addrlen = sizeof(struct sockaddr_in);
+
+	if (getpeername(sockfd, (SSA *) &addr, &addrlen) < 0)
+		return -1;
+
+	snprintf(buf, len, "%s:%d", inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
+
+	return 0;
+}

--- a/http-c-epoll/src/utils/sock/sock_util.h
+++ b/http-c-epoll/src/utils/sock/sock_util.h
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Useful socket macros and structures
+ */
+
+#ifndef SOCK_UTIL_H_
+#define SOCK_UTIL_H_	1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+/* default backlog for listen(2) system call */
+#define DEFAULT_LISTEN_BACKLOG		5
+
+/* "shortcut" for struct sockaddr structure */
+#define SSA			struct sockaddr
+
+
+int tcp_connect_to_server(const char *name, unsigned short port);
+int tcp_close_connection(int s);
+int tcp_create_listener(unsigned short port, int backlog);
+int get_peer_address(int sockfd, char *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/http-c-epoll/src/utils/utils.h
+++ b/http-c-epoll/src/utils/utils.h
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+
+#ifndef UTILS_H_
+#define UTILS_H_ 1
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "log/log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ERR(assertion, call_description)				\
+	do {								\
+		if (assertion)						\
+			log_error("%s: %s",				\
+				call_description, strerror(errno));	\
+	} while (0)
+
+#define DIE(assertion, call_description)				\
+	do {								\
+		if (assertion)	{					\
+			log_fatal("%s: %s",				\
+				call_description, strerror(errno));	\
+			exit(EXIT_FAILURE);				\
+		}							\
+	} while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* UTILS_H_ */

--- a/http-c-epoll/src/w_epoll.h
+++ b/http-c-epoll/src/w_epoll.h
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * epoll wrapper functions
+ */
+
+#ifndef W_EPOLL_H_
+#define W_EPOLL_H_	1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define EPOLL_TIMEOUT_INFINITE		-1
+
+
+static inline int w_epoll_create(void)
+{
+	return epoll_create(10);
+}
+
+static inline int w_epoll_add_fd_in(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
+}
+
+static inline int w_epoll_add_fd_out(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLOUT;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
+}
+
+static inline int w_epoll_add_fd_inout(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN | EPOLLOUT;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
+}
+
+static inline int w_epoll_update_fd_in(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev);
+}
+
+static inline int w_epoll_update_fd_out(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLOUT;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev);
+}
+
+static inline int w_epoll_update_fd_inout(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN | EPOLLOUT;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev);
+}
+
+static inline int w_epoll_remove_fd(int epollfd, int fd)
+{
+	struct epoll_event ev;
+
+	/*
+	 * ev needn't be initialized
+	 * It has to be passed to epoll as a non-NULL argument for
+	 * pre-2.6.9 kernels.
+	 */
+	ev.events = EPOLLIN;
+	ev.data.fd = fd;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_DEL, fd, &ev);
+}
+
+static inline int w_epoll_add_ptr_in(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
+}
+
+static inline int w_epoll_add_ptr_out(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLOUT;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
+}
+
+static inline int w_epoll_add_ptr_inout(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN | EPOLLOUT;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev);
+}
+
+static inline int w_epoll_update_ptr_in(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev);
+}
+
+static inline int w_epoll_update_ptr_out(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLOUT;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev);
+}
+
+static inline int w_epoll_update_ptr_inout(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	ev.events = EPOLLIN | EPOLLOUT;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_MOD, fd, &ev);
+}
+
+static inline int w_epoll_remove_ptr(int epollfd, int fd, void *ptr)
+{
+	struct epoll_event ev;
+
+	/*
+	 * ev needn't be initialized
+	 * It has to be passed to epoll as a non-NULL argument for
+	 * pre-2.6.9 kernels.
+	 */
+	ev.events = EPOLLIN;
+	ev.data.ptr = ptr;
+
+	return epoll_ctl(epollfd, EPOLL_CTL_DEL, fd, &ev);
+}
+
+static inline int w_epoll_wait_infinite(int epollfd, struct epoll_event *rev)
+{
+	return epoll_wait(epollfd, rev, 1, EPOLL_TIMEOUT_INFINITE);
+}
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EPOLL_H_ */


### PR DESCRIPTION
Introduce an epoll-based echo-reply server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: required filesystem (GCC-based) to build server
* `README.md`: document how to use
* `src/`: the epoll server implementation (source code, `Makefile`)