### PR TITLE
feat: Introduce DuckDB Go program

### DIFF
--- a/duckdb0.9-go/Dockerfile
+++ b/duckdb0.9-go/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.21.3-bookworm AS build
+
+WORKDIR /src
+
+COPY ./src /src
+
+RUN set -xe; \
+    go build \
+      -buildmode=pie \
+      -ldflags "-linkmode external -extldflags -static-pie" \
+      -tags netgo \
+      -o /server /src/... \
+    ;
+
+FROM scratch
+
+COPY --from=build /server /server

--- a/duckdb0.9-go/Kraftfile
+++ b/duckdb0.9-go/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: duckdb-go
+
+runtime: index.unikraft.io/unikraft.org/base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]

--- a/duckdb0.9-go/README.md
+++ b/duckdb0.9-go/README.md
@@ -1,0 +1,23 @@
+# DuckDB Go Example
+
+This directory contains a simple Go example using the [DuckDB](https://duckdb.org) library running with Unikraft in binary compatibility mode.
+The Go program is extracted from [DuckDB examples](https://duckdb.org/docs/api/go) and it creates and uses a test database.
+
+## Quick Run
+
+Use `kraft` to run the image:
+
+```console
+kraft run -M 192M
+```
+
+Once executed, it will print out information from the created database:
+
+```text
+id: 42 name: John
+```
+
+## Scripted Run
+
+Use the scripted runs, detailed in the common `../README.md`.
+Running the scripts will print out information ame as above.

--- a/duckdb0.9-go/src/go.mod
+++ b/duckdb0.9-go/src/go.mod
@@ -1,0 +1,7 @@
+module github.com/kraftcloud/examples/duckdb-go
+
+go 1.21.1
+
+require github.com/marcboeker/go-duckdb v1.5.4
+
+require github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/duckdb0.9-go/src/go.sum
+++ b/duckdb0.9-go/src/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/marcboeker/go-duckdb v1.5.4 h1:Cv6gzgrzPnmqJKJiTT2CJM3eUqIT5in9DNyxAn+okgA=
+github.com/marcboeker/go-duckdb v1.5.4/go.mod h1:wm91jO2GNKa6iO9NTcjXIRsW+/ykPoJbQcHSXhdAl28=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/duckdb0.9-go/src/main.go
+++ b/duckdb0.9-go/src/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/marcboeker/go-duckdb"
+)
+
+func main() {
+	db, _ := sql.Open("duckdb", "")
+
+	db.Exec(`CREATE TABLE person (id INTEGER, name VARCHAR)`)
+	db.Exec(`INSERT INTO person VALUES (42, 'John')`)
+
+	var (
+		id   int
+		name string
+	)
+	row := db.QueryRow(`SELECT id, name FROM person`)
+	_ = row.Scan(&id, &name)
+	fmt.Println("id:", id, "name:", name)
+}


### PR DESCRIPTION
Introduce simple DuckDB Go program to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `README.md`: document how to use
* `src/`: the source code files