### PR TITLE
feat: Introduce CHDB Go app with HTTP frontend

### DIFF
--- a/chdb-go-1.2.0/Dockerfile
+++ b/chdb-go-1.2.0/Dockerfile
@@ -1,0 +1,47 @@
+FROM golang:1.21.6-bookworm AS build
+
+WORKDIR /src
+
+ARG LIBCHDB_VERSION=v1.2.0
+RUN set -xe; \
+    apt-get -yqq update; \
+    apt-get -yqq install \
+        git \
+        wget \
+    ;
+
+RUN set -xe; \
+    wget https://github.com/chdb-io/chdb/releases/download/${LIBCHDB_VERSION}/linux-x86_64-libchdb.tar.gz; \
+    tar xzf linux-x86_64-libchdb.tar.gz; \
+    mv /src/libchdb.so /usr/local/lib/libchdb.so; \
+    ldconfig /usr/local/lib/libchdb.so \
+    ;
+
+RUN set -xe; \
+    git clone https://github.com/chdb-io/chdb-go; \
+    cd chdb-go; \
+    git checkout -b br-${LIBCHDB_VERSION} ${LIBCHDB_VERSION} \
+    ;
+
+COPY ./main.go /src/chdb-go/
+
+RUN set -xe; \
+    cd /src/chdb-go; \
+    CGO_ENABLED=1 go build -buildmode=pie -o chdb-go main.go \
+    ;
+
+RUN mkdir /src/tmp
+
+FROM scratch
+
+COPY --from=build /src/chdb-go/chdb-go /chdb-go
+
+COPY --from=build /usr/local/lib/libchdb.so /usr/local/lib/libchdb.so
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+COPY --from=build /src/tmp /tmp

--- a/chdb-go-1.2.0/Kraftfile
+++ b/chdb-go-1.2.0/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/chdb-go"]

--- a/chdb-go-1.2.0/README.md
+++ b/chdb-go-1.2.0/README.md
@@ -1,0 +1,15 @@
+# CHDB Go 1.21 Program.
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, simply invoke:
+
+```console
+kraft cloud deploy -M 1024 -p 443:8080 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/chdb-go-1.2.0/main.go
+++ b/chdb-go-1.2.0/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"net/http"
+
+	"github.com/chdb-io/chdb-go/chdb"
+)
+
+func query_db(w http.ResponseWriter, req *http.Request) {
+	// Stateless Query (ephemeral)
+	result, err := chdb.Query("SELECT version()", "CSV")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(result)
+
+	tmp_path := filepath.Join(os.TempDir(), "chdb_test")
+	// Stateful Query (persistent)
+	session, _ := chdb.NewSession(tmp_path)
+
+	_, err = session.Query("CREATE DATABASE IF NOT EXISTS testdb; " +
+		"CREATE TABLE IF NOT EXISTS testdb.testtable (id UInt32) ENGINE = MergeTree() ORDER BY id;")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	_, err = session.Query("USE testdb; INSERT INTO testtable VALUES (1), (2), (3);")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	ret, err := session.Query("SELECT * FROM testtable;")
+	if err != nil {
+		fmt.Fprintf(w, err.Error())
+	} else {
+		fmt.Fprintf(w, string(ret.Buf()))
+	}
+}
+
+func main() {
+	http.HandleFunc("/", query_db)
+	fmt.Println("Listening on :8080...")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Introduce CHDB Go app with a simple HTTP frontend to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `README.md`: document how to use
* `main.go`: the CHDB Go implementation