### PR TITLE
feat: Introduce H3 server

### DIFF
--- a/h3-0.0.3/Dockerfile
+++ b/h3-0.0.3/Dockerfile
@@ -1,0 +1,28 @@
+FROM rust:1.73.0-bookworm AS build
+
+ARG H3_VERSION=h3-v0.0.3
+
+RUN set -xe; \
+    apt-get -y update; \
+    apt-get -yqq install --no-install-recommends \
+      ca-certificates \
+      wget \
+      xz-utils \
+      git; \
+   git clone https://github.com/hyperium/h3 /src/h3; \
+   cd /src/h3; \
+   git checkout -b br-${H3_VERSION} ${H3_VERSION} \
+   ;
+
+WORKDIR /src/h3
+RUN cargo build --examples
+
+FROM scratch
+
+COPY --from=build /src/h3/target/debug/examples/server /server
+COPY --from=build /src/h3/examples/server.cert /examples/server.cert
+COPY --from=build /src/h3/examples/server.key /examples/server.key
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/h3-0.0.3/Kraftfile
+++ b/h3-0.0.3/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server", "--listen=[::]:443"]

--- a/h3-0.0.3/README.md
+++ b/h3-0.0.3/README.md
@@ -1,0 +1,15 @@
+# h3 0.0.3 Program.
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```console
+kraft cloud deploy -p 443:443 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)


### PR DESCRIPTION
Introduce H3 server (an asynchronous HTTP/3 implementation) to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base` image
* `Dockerfile`: filesystem, including binary and libraries
* `README.md`: document how to use