### PR TITLE
feat(examples): Introduce Rust Tokio

### DIFF
--- a/http-rust1.75-tokio/Cargo.toml
+++ b/http-rust1.75-tokio/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "http-tokio"
+version = "0.1.0"
+edition = "2021"
+
+
+[dependencies]
+tokio = {version = "1",  features = ["rt-multi-thread", "net", "time", "macros", "io-util"] }

--- a/http-rust1.75-tokio/Dockerfile
+++ b/http-rust1.75-tokio/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.75.0-bookworm AS build
+
+WORKDIR /src
+
+COPY ./src /src/src
+COPY ./Cargo.toml /src/Cargo.toml
+
+RUN cargo build
+
+FROM scratch
+
+COPY --from=build src/target/debug/http-tokio /server
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/http-rust1.75-tokio/Kraftfile
+++ b/http-rust1.75-tokio/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/server"]

--- a/http-rust1.75-tokio/README.md
+++ b/http-rust1.75-tokio/README.md
@@ -1,0 +1,29 @@
+# Tokio (Rust) Example
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Start by cloning this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```console
+kraft cloud deploy -p 443:8080 .
+```
+
+Then try visiting one of the available paths:
+- https://<NAME>.<METRO>.kraft.cloud/hello/world
+- https://<NAME>.<METRO>.kraft.cloud/hello/мир
+- https://<NAME>.<METRO>.kraft.cloud/wave/Rocketeer/100
+- https://<NAME>.<METRO>.kraft.cloud/?emoji
+- https://<NAME>.<METRO>.kraft.cloud/?name=Rocketeer
+- https://<NAME>.<METRO>.kraft.cloud/?lang=ру
+- https://<NAME>.<METRO>.kraft.cloud/?lang=ру&emoji
+- https://<NAME>.<METRO>.kraft.cloud/?emoji&lang=en
+- https://<NAME>.<METRO>.kraft.cloud/?name=Rocketeer&lang=en
+- https://<NAME>.<METRO>.kraft.cloud/?emoji&name=Rocketeer
+- https://<NAME>.<METRO>.kraft.cloud/?name=Rocketeer&lang=en&emoji
+- https://<NAME>.<METRO>.kraft.cloud/?lang=ru&emoji&name=Rocketeer
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-rust1.75-tokio/src/main.rs
+++ b/http-rust1.75-tokio/src/main.rs
@@ -1,0 +1,27 @@
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr = SocketAddr::from(([0, 0, 0, 0], 8080));
+    let listener = TcpListener::bind(&addr).await?;
+
+    println!("Listening on: http://{}", addr);
+
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+
+        tokio::spawn(async move {
+            loop {
+                let mut buffer = [0; 1024];
+                let _ = stream.read(&mut buffer).await;
+
+                let contents = "Hello, World!\r\n";
+                let content_length = contents.len();
+                let response = format!("HTTP/1.1 200 OK\r\nContent-Length: {content_length}\r\n\r\n{contents}");
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Introduce Rust Tokio server to be deployed on KraftCloud. It uses binary compatibility mode (i.e. the `base` official image).

Add:

* `Kraftfile`: build / run rules, including pulling the `base:latest` official image
* `Dockerfile`: the application filesystem, comprised of Rust Tokio files and application binary executable
* `README.md`: document how to use
* `Cargo.toml`: Rust Cargo dependency files
* `src/`: the application directory