### PR TITLE
feat(examples): Introduce ExpressJS on Node

### DIFF
--- a/node21-expressjs/.dockerignore
+++ b/node21-expressjs/.dockerignore
@@ -1,0 +1,6 @@
+dist/
+node_modules/
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/node21-expressjs/.gitignore
+++ b/node21-expressjs/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/node21-expressjs/Dockerfile
+++ b/node21-expressjs/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:21-alpine AS build
+
+WORKDIR /usr/src
+
+COPY . /usr/src/
+
+RUN npm install
+
+FROM scratch
+
+# Distribution configuration
+COPY --from=build /etc/os-release /etc/os-release
+
+# Express.js
+COPY --from=build /usr/src/node_modules /usr/src/node_modules
+COPY --from=build /usr/src/app/index.js /usr/src/server.js

--- a/node21-expressjs/Kraftfile
+++ b/node21-expressjs/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: node21-expressjs
+
+runtime: node:21
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/node21-expressjs/README.md
+++ b/node21-expressjs/README.md
@@ -1,0 +1,16 @@
+# Node 21 ExpressJS Example
+
+This example uses the [ExpressJS Node framework](https://expressjs.com/).
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:3000 -M 256 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/node21-expressjs/app/index.js
+++ b/node21-expressjs/app/index.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const app = express()
+const port = 3000
+
+app.get('/', (req, res) => {
+  res.send('Hello, World!\n')
+})
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`)
+})

--- a/node21-expressjs/package.json
+++ b/node21-expressjs/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
Introduce ExpressJS (Node framework) to be deployed on KraftCloud. It uses binary compatibility mode. It uses the `node:21` runtime.

Add:

* `Kraftfile`: build / run rules, including pulling the `node` image
* `Dockerfile`: ExpressJS filesystem
* `README.md`: document how to use
* `package.json`: install dependencies
* `app/index.js`: the actual ExpressJS implementation