### PR TITLE
feat(examples): Introduce Ruby Rails example

### DIFF
--- a/ruby3.2-rails/.dockerignore
+++ b/ruby3.2-rails/.dockerignore
@@ -1,0 +1,4 @@
+/.unikraft/
+/Dockerfile
+/Kraftfile
+/README.md

--- a/ruby3.2-rails/Dockerfile
+++ b/ruby3.2-rails/Dockerfile
@@ -1,0 +1,31 @@
+FROM ruby:3.2.2-bookworm AS build
+
+RUN gem install rails
+RUN rails new app
+
+WORKDIR /app
+RUN rails generate controller hello
+
+COPY . /app/
+
+FROM scratch
+
+# Ruby Gems & Rails contents
+COPY --from=build /usr/local/bundle /usr/local/bundle
+
+# System libraries required by Rails
+COPY --from=build /lib/x86_64-linux-gnu/libcurses.so /lib/x86_64-linux-gnu/libcurses.so
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libffi.so.8 /lib/x86_64-linux-gnu/libffi.so.8
+COPY --from=build /lib/x86_64-linux-gnu/libncurses.so /lib/x86_64-linux-gnu/libncurses.so
+COPY --from=build /lib/x86_64-linux-gnu/libncursesw.so /lib/x86_64-linux-gnu/libncursesw.so
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /lib/x86_64-linux-gnu/libyaml-0.so.2 /lib/x86_64-linux-gnu/libyaml-0.so.2
+
+# Timezone information
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Rails application
+COPY --from=build /app /app

--- a/ruby3.2-rails/Kraftfile
+++ b/ruby3.2-rails/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: ruby:3.2
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/ruby", "/app/bin/rails", "server", "-b", "0.0.0.0"]

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -1,0 +1,17 @@
+# Ruby3.2 Rails
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```console
+kraft cloud deploy -M 1024 -p 443:3000 -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle .
+```
+
+Then query the `/hello` path from the provided URL.
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/ruby3.2-rails/app/controllers/hello_controller.rb
+++ b/ruby3.2-rails/app/controllers/hello_controller.rb
@@ -1,0 +1,5 @@
+class HelloController < ApplicationController
+  def index
+    @text = "Hello, World!"
+  end
+end

--- a/ruby3.2-rails/app/views/hello/index.html.erb
+++ b/ruby3.2-rails/app/views/hello/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Hello World</h1>
+<%= @text %>

--- a/ruby3.2-rails/config/environments/development.rb
+++ b/ruby3.2-rails/config/environments/development.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.hosts.clear
+end

--- a/ruby3.2-rails/config/routes.rb
+++ b/ruby3.2-rails/config/routes.rb
@@ -1,0 +1,3 @@
+Rails.application.routes.draw do
+  get '/hello' => 'hello#index', :as => :hello
+end


### PR DESCRIPTION
Introduce Rails (Ruby framework) to be deployed on KraftCloud. It uses binary compatibility mode. It uses the `ruby:3.2` runtime.

Add:

* `Kraftfile`: build / run rules, including pulling the `ruby` image
* `Dockerfile`: Rails filesystem
* `README.md`: document how to use
* `app/`, `config/`: the actual Rails implementation