### PR TITLE
feat(examples): Introduce Imaginary example

### DIFF
--- a/imaginary/Kraftfile
+++ b/imaginary/Kraftfile
@@ -1,0 +1,5 @@
+spec: v0.6
+
+runtime: imaginary:1.2
+
+cmd: ["/usr/bin/imaginary", "-p", "8080"]

--- a/imaginary/README.md
+++ b/imaginary/README.md
@@ -1,0 +1,15 @@
+# Imaginary
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+Then, clone this repository and `cd` into this directory.
+To deploy this application on KraftCloud, invoke:
+
+```
+kraft cloud deploy -p 443:8080 -M 256 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)


### PR DESCRIPTION
Introduce Imaginary example to be deployed on KraftCloud. It uses binary compatibility mode. It uses the `imaginary:1.2` runtime.

Add:

* `Kraftfile`: build / run rules, including pulling the `imaginary:1.2` image
* `README.md`: document how to use