### PR TITLE
feat(examples): Introduce Spring Boot example

### DIFF
--- a/java17-springboot3.2.x/DemoApplication.java
+++ b/java17-springboot3.2.x/DemoApplication.java
@@ -1,0 +1,18 @@
+package com.example.demo;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@RestController
+public class DemoApplication {
+    public static void main(String[] args) {
+      SpringApplication.run(DemoApplication.class, args);
+    }
+    @GetMapping("/hello")
+    public String hello(@RequestParam(value = "name", defaultValue = "World") String name) {
+      return String.format("Hello %s!", name);
+    }
+}

--- a/java17-springboot3.2.x/Dockerfile
+++ b/java17-springboot3.2.x/Dockerfile
@@ -1,0 +1,40 @@
+FROM  --platform=linux/x86_64 debian:bookworm AS build
+
+RUN set -xe ; \
+    apt -yqq update ; \
+    apt -yqq install default-jre default-jdk curl unzip ;
+
+RUN ldconfig /usr/lib/jvm/java-17-openjdk-amd64/lib/
+
+WORKDIR /src
+
+RUN set -xe ; \
+    curl -G https://start.spring.io/starter.zip \
+         -d applicationName=DemoApplication \
+         -d artifactId=demo \
+         -d bootVersion=3.2.2 \
+         -d dependencies=web \
+         -d description=com.example \
+         -d javaVersion=17 \
+         -d language=java \
+         -d name=demo \
+         -d packageName=com.example.demo \
+         -d packaging=jar \
+         -d type=maven-project \
+         -d version=0.0.1-SNAPSHOT \
+         -o demo.zip ; \
+    unzip demo.zip \
+    ;
+
+COPY DemoApplication.java src/main/java/com/example/demo/
+
+RUN set -xe ; \
+    ./mvnw compile package install
+
+RUN set -xe ; \
+    mkdir /tmpdir
+
+FROM scratch
+
+COPY --from=build /tmpdir /tmp
+COPY --from=build /src/target/demo-0.0.1-SNAPSHOT.jar /usr/src/demo-0.0.1-SNAPSHOT.jar

--- a/java17-springboot3.2.x/Kraftfile
+++ b/java17-springboot3.2.x/Kraftfile
@@ -1,0 +1,8 @@
+spec: v0.6
+
+runtime: java:17
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/demo-0.0.1-SNAPSHOT.jar"]
+

--- a/java17-springboot3.2.x/README.md
+++ b/java17-springboot3.2.x/README.md
@@ -1,0 +1,21 @@
+# Spring Boot on KraftCloud
+
+[Spring Boot](https://spring.io/projects/spring-boot) is an extension of the Spring plaform for Java that simplifies the creation of Spring applicaitons.
+
+This repository provides the [quickstart example of Spring Boot](https://spring.io/quickstart) over Unikraft. This implements a "Hello World!" endpoint which a browser can connect to.
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+To deploy this application on KraftCloud, invoke:
+
+```console
+kraft cloud deploy -M 1024 -p 443:8080 .
+```
+
+The command will build and deploy `DemoApplication.java`. Feel free to modify and redeploy!
+
+## Learn more
+
+- [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/html/)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)


### PR DESCRIPTION
Introduce Spring Boot example based on the `java:17` runtime.

Add Dockerfile to configure and fetch project template from [https://start.spring.io](https://start.spring.io). Replace `DemoApplication.java` with "Hello World" example from [https://spring.io/quickstart](https://spring.io/quickstart).
