### PR TITLE
Make README.md contents uniform

### DIFF
--- a/caddy/README.md
+++ b/caddy/README.md
@@ -1,19 +1,20 @@
-# Caddy on KraftCloud
+# Caddy
 
 [Caddy](https://caddyserver.com/) is a powerful, enterprise-ready, open source web server with automatic HTTPS written in Go.
 
-
-To run Caddy on KraftCloud, clone this examples repository and `cd` into this directory, then invoke:
+To run Caddy on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:2015 .
+kraft cloud deploy --metro fra0 -p 443:2015 .
 ```
 
-The command will build and deploy the files under `rootfs`. Feel free to modify and redeploy!
+The command will build and deploy the files under `rootfs/`.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
 - [Caddy's Documentation](https://caddyserver.com/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
-
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/dragonflydb/README.md
+++ b/dragonflydb/README.md
@@ -1,20 +1,18 @@
 # DragonflyDB
 
-This examples demonstrates how to use [DragonflyDB](https://www.dragonflydb.io/), a simple, performant, and cost-efficient in-memory data store.
+[DragonflyDB](https://www.dragonflydb.io/) is a simple, performant, and cost-efficient in-memory data store.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
-
-```console
-kraft cloud deploy -p 443:6379 -M 512 .
-```
-
-Get the results of the deployment by running:
+To run DragonflyDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-curl  https://green-leaf-29gzos5s.dal0.kraft.cloud
+kraft cloud deploy --metro fra0 -p 443:6379 -M 512 .
 ```
+
+After deploying, you can use `redis-cli` to query the service using the provided URL.
 
 ## Learn more
 
+- [DragonflyDBS's Documentation](https://www.dragonflydb.io/docs)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/duckdb-go/README.md
+++ b/duckdb-go/README.md
@@ -1,28 +1,20 @@
 # DuckDB using Go SDK
 
-This examples demonstrates how to use [DuckDB](https://duckdb.org), an in-process SQL OLAP database management system, in your Go project.
+[DuckDB](https://duckdb.org) is an in-process SQL OLAP database management system, in your Go project.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
-
-```console
-kraft cloud deploy -p 443:8080 .
-```
-
-Get the results of the deployment by running:
+To run DuckDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-curl  https://green-leaf-29gzos5s.dal0.kraft.cloud
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
 
-Or by inspecting the logs:
+The command will build and deploy the files under `src/`.
 
-```console
-kraft cloud instance logs duckdb-go-8qv5t
-```
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
 - [DuckDB's Go driver](https://duckdb.org/docs/api/go)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,21 +1,18 @@
 # Grafana
 
-This examples demonstrates how to use [Grafana](https://grafana.com), the open source analytics & monitoring solution for every database.
+[Grafana](https://grafana.com) is the open source analytics & monitoring solution for every database.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
-
-```console
-kraft cloud deploy -p 443:3000 -M 1024 .
-```
-
-Get the results of the deployment by visiting the webpage or using `curl`:
+To run Grafana on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-curl  https://green-leaf-29gzos5s.dal0.kraft.cloud/login
+kraft cloud deploy --metro fra0 -p 443:3000 -M 1024 .
 ```
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Grafana's Documentation](https://grafana.com/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -1,21 +1,18 @@
 # HAProxy
 
-This example demonstrates how to use [HAProxy](https://www.haproxy.org), a free and open source software that provides a high availability load balancer and reverse proxy for TCP and HTTP-based applications that spreads requests across multiple servers.
+[HAProxy](https://www.haproxy.org) is a free and open source software that provides a high availability load balancer and reverse proxy for TCP and HTTP-based applications that spreads requests across multiple servers.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
-
-```console
-kraft cloud deploy -p 443:8404 -M 256 .
-```
-
-Get the results of the deployment by running or visiting the website:
+To run HAProxy on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-curl  https://green-leaf-29gzos5s.dal0.kraft.cloud/stats
+kraft cloud deploy --metro fra0 -p 443:8404 -M 256 .
 ```
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [HAProxy's Documentation](https://docs.haproxy.org/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-c/README.md
+++ b/http-c/README.md
@@ -1,15 +1,19 @@
-# Simple C HTTP Web Server
+# Simple C HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the C programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, simply invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will build and deploy the `http_server.c` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-cpp-boost/README.md
+++ b/http-cpp-boost/README.md
@@ -1,15 +1,20 @@
-# Simple C++ Boost HTTP Web Server
+# C++ Boost
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Boost](https://www.boost.org/doc/) is a set of libraries for the C++ programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will build and deploy the `http_server.cpp` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Boost's Documentation](https://www.boost.org/doc/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-cpp/README.md
+++ b/http-cpp/README.md
@@ -1,15 +1,19 @@
-# Simple C++ HTTP Web Server
+# Simple C++ HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the C++ programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, simply invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will build and deploy the `http_server.cpp` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-go1.21/README.md
+++ b/http-go1.21/README.md
@@ -1,15 +1,20 @@
-# Simple Go 1.21 HTTP Web Server
+# Simple Go 1.21 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Go](https://go.dev/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, simply invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will build and deploy the `server.go` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Go's Documentation](https://go.dev/doc/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-java17/README.md
+++ b/http-java17/README.md
@@ -1,15 +1,20 @@
-# Java on KraftCloud
+# Simple Java 17 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Java](https://www.java.com/en/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```
-kraft cloud deploy -p 443:8080 -M 512 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 512 .
 ```
+
+The command will build and deploy the `SimpleHTTPServer.java` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Java's Documentation](https://docs.oracle.com/en/java/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-lua5.1/README.md
+++ b/http-lua5.1/README.md
@@ -1,15 +1,20 @@
-# Lua 5.1.5 HTTP Web Server
+# Simple Lua 5.1.5 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Lua](https://www.lua.org/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will deploy the `http_server.lua` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Lua's Documentation](https://www.lua.org/docs.html)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-node21/README.md
+++ b/http-node21/README.md
@@ -1,15 +1,20 @@
-# Simple Node21 HTTP Web Server
+# Node21
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Node,js](https://nodejs.org) is a free, open-source, cross-platform JavaScript runtime environment.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Node.js on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 256 .
 ```
+
+The command will deploy the `server.js` file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Node.js's Documentation](https://nodejs.org/docs/latest/api/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-perl5.38/README.md
+++ b/http-perl5.38/README.md
@@ -1,15 +1,20 @@
-# Simple Perl5.38 HTTP Web Server
+# Simple Perl5.38 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Perl](https://www.perl.org/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 -M 512 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 512 .
 ```
+
+The command will deploy the `server.pl` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Perl's Documentation](https://www.perl.org/docs.html)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-php8.2/README.md
+++ b/http-php8.2/README.md
@@ -1,15 +1,20 @@
-# Simple PHP8.2 HTTP Web Server
+# Simple PHP8.2 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [PHP](https://www.php.net/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 256 .
 ```
+
+The command will deploy the `server.php` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [PHP's Documentation](https://www.php.net/docs.php)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-python3.12-django5.0/README.md
+++ b/http-python3.12-django5.0/README.md
@@ -1,19 +1,25 @@
-# Python Django web application
+# Python Django
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Django](https://www.djangoproject.com/) is a high-level Python web framework that encourages rapid development and clean, pragmatic design.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Django on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
 kraft cloud deploy -M 512 -p 443:80 .
 ```
 
+The command will deploy files in the current directory.
+
+After deploying, you can query the service using the provided URL.
+
 ## Important notes
 
-The example sets ALLOWED_HOSTS to `*` and runs in debug mode. For a production site read the deployment guides of the Django project carefully.
+The example sets `ALLOWED_HOSTS` to `*` and runs in debug mode.
+For a production site read the deployment guides of the Django project carefully.
 
 ## Learn more
 
+- [Django's Documentation](https://docs.djangoproject.com/en/5.0/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-python3.12-flask3.0/README.md
+++ b/http-python3.12-flask3.0/README.md
@@ -1,15 +1,20 @@
-# Python Flask HTTP Web Server
+# Python Flask
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Flask](https://flask.palletsprojects.com/en/3.0.x/) is a micro web framework written in Python.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Flask on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 512 -p 443:8080 .
+kraft cloud deploy --metro fra0 -M 512 -p 443:8080 .
 ```
+
+The command will deploy files in the current directory.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Flask's Documentation](https://flask.palletsprojects.com/en/3.0.x/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-python3.12/README.md
+++ b/http-python3.12/README.md
@@ -1,15 +1,20 @@
-# Simple Python 3.12 HTTP Web Server
+# Simple Python 3.12 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Python](https://www.python.org/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 -M 512 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 512 .
 ```
+
+The command will build the `server.py` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Python's Documentation](https://www.python.org/doc/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-ruby3.2/README.md
+++ b/http-ruby3.2/README.md
@@ -1,15 +1,20 @@
-# Simple Ruby3.2 HTTP Web Server
+# Simple Ruby3.2 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Ruby](https://www.ruby-lang.org/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 256 .
 ```
+
+The command will deploy the `server.rb` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Ruby's Documentation](https://www.ruby-lang.org/en/documentation/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.73/README.md
+++ b/http-rust1.73/README.md
@@ -1,15 +1,20 @@
-# Simple Rust 1.73 HTTP Web Server
+# Simple Rust 1.73 HTTP Server
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This is a simple HTTP server written in the [Rust](https://www.rust-lang.org/) programming language.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will build and deploy the `server.rs` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Rust's Documentation](https://www.rust-lang.org/learn)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.75-actix-web4/README.md
+++ b/http-rust1.75-actix-web4/README.md
@@ -1,16 +1,20 @@
-# Rocket v0.5 (Rust) Example
+# Rust Actix Web
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Actix Web](https://actix.rs/) is a powerful, pragmatic, and extremely fast web framework for Rust.
 
-Start by cloning this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Actix Web on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
+
+The command will build and deploy the files under `src/`.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
 - [Actix's Documentation](https://actix.rs/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.75-rocket0.5/README.md
+++ b/http-rust1.75-rocket0.5/README.md
@@ -1,31 +1,21 @@
-# Rocket v0.5 (Rust) Example
+# Rust Rocket v0.5
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Rocket](https://rocket.rs/) is web framework for Rust that makes it simple to write fast, type-safe, secure web applications.
 
-This example was derived from [Rocket's "hello" example](https://github.com/rwf2/Rocket/tree/v0.5/examples/hello).
-
-Start by cloning this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Rocket on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
 
-Then try visiting one of the available paths:
-- https://<NAME>.<METRO>.kraft.cloud/hello/world
-- https://<NAME>.<METRO>.kraft.cloud/hello/мир
-- https://<NAME>.<METRO>.kraft.cloud/wave/Rocketeer/100
-- https://<NAME>.<METRO>.kraft.cloud/?emoji
-- https://<NAME>.<METRO>.kraft.cloud/?name=Rocketeer
-- https://<NAME>.<METRO>.kraft.cloud/?lang=ру
-- https://<NAME>.<METRO>.kraft.cloud/?lang=ру&emoji
-- https://<NAME>.<METRO>.kraft.cloud/?emoji&lang=en
-- https://<NAME>.<METRO>.kraft.cloud/?name=Rocketeer&lang=en
-- https://<NAME>.<METRO>.kraft.cloud/?emoji&name=Rocketeer
-- https://<NAME>.<METRO>.kraft.cloud/?name=Rocketeer&lang=en&emoji
-- https://<NAME>.<METRO>.kraft.cloud/?lang=ru&emoji&name=Rocketeer
+The command will build and deploy the files under `src/`.
+
+After deploying, you can query the service using the provided URL, followed by paths such as `hello/world`.
+See more in the `src/main.rs` source code file.
 
 ## Learn more
 
+- [Rockets's Documentation](https://api.rocket.rs/v0.5/rocket/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-rust1.75-tokio/README.md
+++ b/http-rust1.75-tokio/README.md
@@ -1,17 +1,20 @@
-# Tokio (Rust) Example
+# Rust Tokio
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Tokio](https://tokio.rs/) is a runtime for writing reliable asynchronous applications with Rust.
 
-Start by cloning this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Tokio on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
 
-Then try using curl on the resulting URL.
+The command will build and deploy the files under `src/`.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Tokios's Documentation](https://docs.rs/tokio/latest/tokio/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/hugo/README.md
+++ b/hugo/README.md
@@ -1,21 +1,20 @@
-# Hugo Server
+# Hugo
 
-This example demonstrates how to use [Hugo](https://gohugo.io/commands/hugo_server/), a high performance webserver, with the [ananke](https://github.com/budparr/gohugo-theme-ananke.git) theme.
+[Hugo](https://gohugo.io/) is one of the most popular open-source static site generators.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
-
-```console
-kraft cloud deploy -p 443:1313 -M 512 .
-```
-
-Fetch the URL from the output and open it in your browser or use `curl`:
+To run Hugo on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-curl https://falling-silence-wb7fv6nr.dal0.kraft.cloud
+kraft cloud deploy --metro fra0 -p 443:1313 -M 512 .
 ```
+
+The command will deploy the files under `site/`.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Hugo's Documentation](https://gohugo.io/documentation/).
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/imaginary/README.md
+++ b/imaginary/README.md
@@ -1,15 +1,18 @@
 # Imaginary
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Imaginary](https://github.com/h2non/imaginary) is a fast, simple, scalable, Docker-ready HTTP microservice for high-level image processing.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Imaginary on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:8080 -M 256 .
 ```
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Imaginary's Documentation](https://fly.io/docs/app-guides/run-a-global-image-service/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/java17-springboot3.2.x/README.md
+++ b/java17-springboot3.2.x/README.md
@@ -1,21 +1,20 @@
-# Spring Boot on KraftCloud
+# Spring Boot
 
 [Spring Boot](https://spring.io/projects/spring-boot) is an extension of the Spring plaform for Java that simplifies the creation of Spring applicaitons.
 
-This repository provides the [quickstart example of Spring Boot](https://spring.io/quickstart) over Unikraft. This implements a "Hello World!" endpoint which a browser can connect to.
-
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
-
-To deploy this application on KraftCloud, invoke:
+To run SpringBoot on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 1024 -p 443:8080 .
+kraft cloud deploy --metro fra0 -M 1024 -p 443:8080 .
 ```
 
-The command will build and deploy `DemoApplication.java`. Feel free to modify and redeploy!
+The command will build and deploy the `DemoApplication.java` source code file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
 - [Spring Boot Reference](https://docs.spring.io/spring-boot/docs/current/reference/html/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/llama2/README.md
+++ b/llama2/README.md
@@ -1,18 +1,22 @@
-# Llama2 inference
+# Llama2.c Inference
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Llama2.c](https://github.com/karpathy/llama2.c) is Llama2 inference in one file of pure C.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, simply invoke:
+To run LLama2.c on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 1024 -p 443:8080 .
+kraft cloud deploy --metro fra0 -M 1024 -p 443:8080 .
 ```
 
-Note that in this example we assign 1G of memory. The amount required
-will vary depending on the model.
+The command will build and deploy the files under `rootfs/`.
+Note that in this example we assign 1G of memory.
+The amount required will vary depending on the model.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Llama2.c's Documentation](https://github.com/karpathy/llama2.c/blob/master/README.md)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -1,18 +1,18 @@
 # MariaDB
 
-This examples demonstrates how to use [MariaDB](https://mariadb.org), one of the most popular open source relational databases.
+[MariaDB](https://mariadb.org/) is one of the most popular open source relational databases.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
+To run MariaDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 3306:3306/tls -M 1024 .
+kraft cloud deploy --metro fra0 -p 3306:3306/tls -M 1024 .
 ```
 
 Get the results of the deployment by first forwarding the port (save the returned PID):
 
 ```console
-socat tcp-listen:3306,bind=127.0.0.1,fork,reuseaddr openssl:broken-shadow-990cz9og.dal0.kraft.cloud:3306 &
+socat tcp-listen:3306,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:3306 &
 ```
 
 Then, run the following command to test that it works:
@@ -21,7 +21,7 @@ Then, run the following command to test that it works:
 mysql -h 127.0.0.1 -u root -punikraft mysql <<< "select count(*) from user"
 ```
 
-To stop the socat process, run:
+To stop the `socat` process, run:
 
 ```console
 kill -9 <PID>
@@ -29,5 +29,6 @@ kill -9 <PID>
 
 ## Learn more
 
+- [MariaDB's Documentation](https://mariadb.org/documentation/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -1,18 +1,18 @@
 # Memcached
 
-This examples demonstrates how to use [Memcached](https://memcached.org), n in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
+[Memcached](https://memcached.org) is an in-memory key-value store for small chunks of arbitrary data (strings, objects) from results of database calls, API calls, or page rendering.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
+To run Memcached on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 11211:11211/tls -M 256 .
+kraft cloud deploy --metro fra0 -p 11211:11211/tls -M 256 .
 ```
 
 Get the results of the deployment by first forwarding the port (save the returned PID):
 
 ```console
-socat tcp-listen:11211,bind=127.0.0.1,fork,reuseaddr openssl:broken-shadow-990cz9og.dal0.kraft.cloud:11211 &
+socat tcp-listen:11211,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:11211 &
 ```
 
 Then, run the following commands to test that it works (you should see output when incrementing):
@@ -35,5 +35,6 @@ kill -9 <PID>
 
 ## Learn more
 
+- [Memcached's Documentation](https://github.com/memcached/memcached/wiki)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/minio/README.md
+++ b/minio/README.md
@@ -1,21 +1,18 @@
 # MinIO
 
-This examples demonstrates how to use [MinIO](https://min.io), a High Performance Object Storage which is Open Source, Amazon S3 compatible, Kubernetes Native and is designed for cloud native workloads like AI.
+[MinIO](https://min.io/) is a High-Performance Object Storage system.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
-
-```console
-kraft cloud deploy -p 443:9001/http+tls -p 9000:9000/tls -M 512 .
-```
-
-Get the results of the deployment by running the following command or visiting the website:
+To run MinIO on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-curl https://spring-wood-6qlhc4ck.dal0.kraft.cloud
+kraft cloud deploy --metro fra0 -p 443:9001/http+tls -p 9000:9000/tls -M 512 .
 ```
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [MinIO's Documentation](https://min.io/docs/minio/kubernetes/upstream/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -1,30 +1,34 @@
 # MongoDB
 
-This examples demonstrates how to use [MongoDB](https://www.mongodb.com), a source-available, cross-platform, document-oriented database program.
+[MongoDB](https://www.mongodb.com) is a source-available, cross-platform, document-oriented database program.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
+To run MongoDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 27017:27017/tls -M 1024 .
+kraft cloud deploy --metro fra0 -p 27017:27017/tls -M 1024 .
 ```
 
 To connect, you first need to create a tunnel to the remote server (save the returned PID):
+
 ```console
-socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:solitary-breeze-ou8bygcn.dal0.kraft.cloud:27017 &
+socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:27017 &
 ```
 
 Then you can use the `mongo` client to connect to the server:
+
 ```console
 mongosh mongodb://localhost
 ```
 
-To disconnect, simply kill the `socat` process:
+To stop the `socat` process, run:
+
 ```console
 kill -9 <PID>
 ```
 
 ## Learn more
 
+- [MongoDB's Documentation](https://www.mongodb.com/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,18 +1,20 @@
-# Nginx on KraftCloud
+# NGINX
 
-[Nginx](https://nginxr.com/) is a web server that can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache
+[NGINX](https://www.nginx.com/) is a web server that can also be used as a reverse proxy, load balancer, mail proxy and HTTP cache.
 
-To run Nginx on KraftCloud, clone this examples repository and `cd` into this directory, then invoke:
+To run NGINX on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy --metro fra0 -p 443:8080 .
 ```
 
-The command will build and deploy the files under the `rootfs/` directory.
-Feel free to modify and redeploy!
+The command will deploy the files under `rootfs/`.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [NGINX's Documentation](https://nginx.org/en/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
-
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node18-prisma-rest-express/README.md
+++ b/node18-prisma-rest-express/README.md
@@ -1,4 +1,4 @@
-# Node 18 Prisma REST API Example
+# Node 18 Prisma
 
 This example is derived from [Prisma's REST API Example](https://github.com/prisma/prisma-examples/tree/latest/javascript/rest-express) and shows how to implement a **REST API** using [Express](https://expressjs.com/) and [Prisma Client](https://www.prisma.io/docs/concepts/components/prisma-client) and deploy it onto KraftCloud.
 It uses a SQLite database file with some initial dummy data which you can find at [`./prisma/store.db`](./prisma/store.db).
@@ -41,16 +41,15 @@ You can send the API requests implemented in `index.js`, e.g.
 ### 3. Deploy to KraftCloud
 
 To deploy this project onto KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
-
-Then invoke:
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 512 -p 443:3000 .
+kraft cloud deploy --metro fra0 -M 512 -p 443:3000 .
 ```
 
-After packaging and deploying the project onto KraftCloud, you can access the same API via the FQDN, e.g.
-[`https://polished-rain-413iy826.fra0.kraft.cloud/feed`](https://polished-rain-413iy826.fra0.kraft.cloud/feed).
+The command will deploy the files in the current directory.
 
+After deploying, you can query the service using the provided URL.
 
 ## Using the REST API
 
@@ -323,3 +322,5 @@ datasource db {
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
 - [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
 - [Prisma's Documentation docs](https://www.prisma.io/docs)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-expressjs/README.md
+++ b/node21-expressjs/README.md
@@ -1,16 +1,20 @@
-# Node 21 ExpressJS Example
+# Node 21 Express
 
-This example uses the [ExpressJS Node framework](https://expressjs.com/).
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Express](https://expressjs.com/) is a fast, unopinionated, minimalist web framework for Node.js.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Express on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:3000 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:3000 -M 256 .
 ```
+
+The command will deploy the files under `app/`.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Express's Documentation](https://expressjs.com/en/5x/api.html)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-nextjs/README.md
+++ b/node21-nextjs/README.md
@@ -1,16 +1,20 @@
-# Node 21 NextJS Example
+# Node 21 NextJS
 
-This example uses the [NextJS Node framework](https://nextjs.org/).
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[NextJS](https://nextjs.org/) enables you to create high-quality web applications with the power of React components.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run NextJS on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:3000 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:3000 -M 256 .
 ```
+
+The command will build the files in the current directory.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [NextJS's Documentation](https://nextjs.org/docs)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-remix/README.md
+++ b/node21-remix/README.md
@@ -1,16 +1,20 @@
-# Node 21 Remix Example
+# Node 21 Remix
 
-This example uses the [Remix](https://remix.run/).
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Remix](https://remix.run/)  is a full stack web framework that lets you focus on the user interface and work back through web standards to deliver a fast, slick, and resilient user experience.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Remix on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:3000 -M 512 .
+kraft cloud deploy --metro fra0 -p 443:3000 -M 512 .
 ```
+
+The command will deploy the files in the current directory.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Remix's Documentation](https://remix.run/docs/en/main)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/node21-solid-start/README.md
+++ b/node21-solid-start/README.md
@@ -1,16 +1,20 @@
-# Node 21 Solid Start Example
+# Node 21 Solid Start
 
-This example uses the [Solid Start framework](https://start.solidjs.com).
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Solid Start](https://start.solidjs.com/) a meta-framework that provides the platform to put all of web-related pieces together in a one location.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Solid Start on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:3000 -M 256 .
+kraft cloud deploy --metro fra0 -p 443:3000 -M 256 .
 ```
+
+The command will deploy the files in the current directory.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Solid Starts's Documentation](https://start.solidjs.com/getting-started/what-is-solidstart)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -1,15 +1,17 @@
-# OpenTelemetry Collector on KraftCloud
+# OpenTelemetry Collector
 
-The [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) offers a vendor-agnostic implementation of how to receive, process and export telemetry data.
 
-
-To run OpenTelemetry Collector on KraftCloud, clone this examples repository and `cd` into this directory, then invoke:
+To run OpenTelemetry Collector on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy .
+kraft cloud deploy --metro fra0 .
 ```
 
-The command will build and deploy the files under `rootfs` in a Collector instance. The default configuration can receive telemetry data from other instances by specifying the private IP or internal DNS as destination. The only configured exporter is the debug exporter. Feel free to modify and redeploy!
+The command will build and deploy the files under `rootfs` in a Collector instance.
+The default configuration can receive telemetry data from other instances by specifying the private IP or internal DNS as destination.
+The only configured exporter is the debug exporter. Feel free to modify and redeploy!
 
 If you want to use your own configuration, please note that you have to disable the self-telemetry feature:
 
@@ -24,5 +26,4 @@ service:
 
 - [OpenTelemetry Collectors Documentation](https://opentelemetry.io/docs/collector/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
-
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/python3.12-flask3.0-sqlite/README.md
+++ b/python3.12-flask3.0-sqlite/README.md
@@ -1,15 +1,20 @@
-# Python Flask SQLite
+# Python Flask
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Flask](https://flask.palletsprojects.com/en/3.0.x/) is a micro web framework written in Python.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Flask on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 512 -p 443:8080 .
+kraft cloud deploy --metro fra0 -M 512 -p 443:8080 .
 ```
+
+The command will deploy files in the current directory.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Flask's Documentation](https://flask.palletsprojects.com/en/3.0.x/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,18 +1,18 @@
 # Redis
 
-This examples demonstrates how to use [Redis](https://redis.io), an open-source in-memory storage, used as a distributed, in-memory key–value database, cache and message broker, with optional durability.
+[Redis](https://redis.io) is an open-source in-memory storage, used as a distributed, in-memory key–value database, cache and message broker, with optional durability.
 
-To get started, simply clone this repository and `cd` into this directory.
-Then, run:
+To run Redis on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 6379:6379/tls -M 512 .
+kraft cloud deploy --metro fra0 -p 6379:6379/tls -M 512 .
 ```
 
 First, open a connection to the Redis server (save the pid):
 
 ```console
-socat tcp-listen:6379,bind=127.0.0.1,fork,reuseaddr openssl:dark-night-g652ndeb.dal0.kraft.cloud:6379 &
+socat tcp-listen:6379,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:6379 &
 ```
 
 Then use `redis-cli` or `redis-benchmark` to test the connection (keep in mind that `socat` will also slow down your benchmark):
@@ -29,5 +29,6 @@ kill -9 <PID>
 
 ## Learn more
 
+- [Redis's Documentation](https://redis.io/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -1,17 +1,21 @@
 # Ruby3.2 Rails
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+[Rails](https://rubyonrails.org/) is a server-side web application framework written in Ruby.
 
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, invoke:
+To run Rails on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 1024 -p 443:3000 -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle .
+kraft cloud deploy --metro fra0 -M 1024 -p 443:3000 -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle .
 ```
 
-Then query the `/hello` path from the provided URL.
+The command will build and deploy the files under `rootfs/`.
+
+After deploying, you can query the service using the provided URL.
+Use the `/hello` path for the provided URL.
 
 ## Learn more
 
+- [Rails's Documentation](https://guides.rubyonrails.org/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/skipper/README.md
+++ b/skipper/README.md
@@ -2,13 +2,19 @@
 
 [Skipper](https://opensource.zalando.com/skipper/) is an HTTP router and reverse proxy for service composition.
 
-To run Skipper on KraftCloud, clone this examples repository and `cd` into this directory, then invoke:
+To run Skipper on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:9090 .
+kraft cloud deploy --metro fra0 -p 443:9090 .
 ```
+
+The command will deploy the `example.eskip` configuration file.
+
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Skipper's Documentation](https://opensource.zalando.com/skipper/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -2,40 +2,20 @@
 
 This example is derived from [Spin's `spin-wagi-http` example](https://github.com/fermyon/spin/tree/v2.1.0/examples/spin-wagi-http) and shows how to run a Spin application serving routes from two programs written in different languages (Rust and C++) using both the Spin executor and the Wagi executor on KraftCloud.
 
-To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
-
-Then, clone this repository and `cd` into this directory.
-To deploy this application on KraftCloud, simply invoke:
+To run Spin Wagi on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:3000 -M 2048 .
+kraft cloud deploy --metro fra0 -p 443:3000 -M 2048 .
 ```
 
-Then `curl` the hello route:
+The command will build and deploy the files in the current directory.
 
-```console
-$ curl -i https://little-bird-4f8zuwj5.fra0.kraft.cloud/hello
-HTTP/1.1 200 OK
-content-type: application/text
-content-length: 7
-date: Thu, 10 Mar 2022 21:38:34 GMT
-
-Hello
-```
-
-And `curl` the goodbye route:
-
-```console
-$ curl -i https://little-bird-4f8zuwj5.fra0.kraft.cloud/goodbye
-HTTP/1.1 200 OK
-foo: bar
-content-length: 7
-date: Thu, 10 Mar 2022 21:38:58 GMT
-
-Goodbye
-```
+After deploying, you can query the service using the provided URL.
+Use the `/hello` and `/goodbye` paths for the URL.
 
 ## Learn more
 
+- [Spin's Documentation](https://developer.fermyon.com/spin/v2/index)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -2,24 +2,22 @@
 
 [Traefik](https://traefik.io/traefik/) is the leading open-source reverse proxy and load balancer for HTTP and TCP-based applications.
 
-
-To run Traefik on KraftCloud, clone this examples repository and `cd` into this directory, then invoke:
+To run Traefik on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 512 -p 443:80/tls+http -p 8080:8080/tls .
+kraft cloud deploy --metro fra0 -M 512 -p 443:80/tls+http -p 8080:8080/tls .
 ```
+
+The command will deploy the `default.toml` configuration file.
 
 Important security note: this exposes the dashboard on port 8080 *without* authentication.
 
-To check for output you can use `curl`, or a browser:
-
-```console
-curl https://holy-cherry-rye39b1x.dal0.kraft.cloud:8080/dashboard
-```
+After deploying, you can query the service using the provided URL.
+Use the `/dashboard` path for the URL.
 
 ## Learn more
 
-- [Caddy's Documentation](https://caddyserver.com/docs/)
+- [Traefik's Documentation](https://doc.traefik.io/traefik/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
-- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)
-
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/wazero-import-go/README.md
+++ b/wazero-import-go/README.md
@@ -1,46 +1,19 @@
 # WASM (Wazero) on Go
 
 This example is derived from [Wazero's "import go" example](https://github.com/tetratelabs/wazero/tree/main/examples/import-go) and shows how to define, import and call a wasm blob from Go and run it on KraftCloud.
-
 In the example, if the current year is 2024, and we give the argument 2000, [age-calculator.go](age-calculator.go) should output 24.
 
-First build and deploy the application via:
+To run Wazero on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -p 443:8080 . /age-calculator 2000
+kraft cloud deploy --metro fra0 -p 443:8080 . /age-calculator 2000
 ```
 
-Then access the logs via `kraft cloud instance logs` and you should see:
-
-```
-println >> 24
-log_i32 >> 24
-```
-
-Or `curl` the endpoint to get the same result:
-
-```console
-curl https://dry-meadow-qi5e3ztl.dal0.kraft.cloud
-```
-
-## Background
-
-WebAssembly has neither a mechanism to get the current year, nor one to print to the console, so we define these in Go.
-Similar to Go, WebAssembly functions are namespaced into modules instead of packages. Just like Go, only exported
-functions can be imported into another module. What you'll learn in [age-calculator.go](age-calculator.go), is how to
-export functions using [HostModuleBuilder](https://pkg.go.dev/github.com/tetratelabs/wazero#HostModuleBuilder) and how a
-WebAssembly module defined in its [text format](https://www.w3.org/TR/2019/REC-wasm-core-1-20191205/#text-format%E2%91%A0)
-imports it. This only uses the text format for demonstration purposes, to show you what's going on. It is likely, you
-will use another language to compile a Wasm (WebAssembly Module) binary, such as TinyGo. Regardless of how wasm is
-produced, the export/import mechanics are the same!
-
-### [WebAssembly System Interface (WASI)](../../imports/wasi_snapshot_preview1/example)
-
-This uses an ad-hoc Go-defined function to print to the console. There is an emerging specification to standardize
-system calls (similar to Go's [x/sys](https://pkg.go.dev/golang.org/x/sys/unix)) called WebAssembly System Interface
-[(WASI)](https://github.com/WebAssembly/WASI). While this is not yet a W3C standard, wazero includes a
-[wasi package](https://pkg.go.dev/github.com/tetratelabs/wazero/wasi).
+After deploying, you can query the service using the provided URL.
 
 ## Learn more
 
+- [Wazero's Documentation](https://wazero.io/docs/)
 - [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)


### PR DESCRIPTION
`README.md` contents differ between examples. Some feature broken links or missing information. Add all required information and make `README.md` files uniform across all examples.