### PR TITLE
feat(examples): Introduce FerretDB

### DIFF
--- a/ferretdb/.dockerignore
+++ b/ferretdb/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/ferretdb/.gitignore
+++ b/ferretdb/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/ferretdb/Dockerfile
+++ b/ferretdb/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bookworm AS build
+
+RUN set -xe; \
+    echo "Your code here"
+
+FROM scratch
+
+# Copy your files here
+# COPY --from=build / /

--- a/ferretdb/Kraftfile
+++ b/ferretdb/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: ferretdb:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/ferretdb"]

--- a/ferretdb/README.md
+++ b/ferretdb/README.md
@@ -1,0 +1,46 @@
+# FerretDB
+
+[FerretDB](https://www.ferretdb.com/) is an open-source proxy that translates MongoDB wire protocol queries to SQL.
+
+To run FerretDB on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+To deploy it, you need to deploy a [PostgreSQL instance](https://github.com/kraftcloud/examples/tree/main/postgres16.2) using the `examples` repository:
+
+```console
+kraft cloud deploy --metro fra0 --start -M 1024 -e POSTGRES_PASSWORD=unikraft --name postgres .
+```
+
+After deploying PostgreSQL, assuming the internal URL is `postgres.internal`, deploy FerretDB.
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud deploy --metro fra0 -M 512 -p 27017:27017/tls -e FERRETDB_HANDLER=pg -e FERRETDB_POSTGRESQL_URL=postgres://postgres.internal:5432 -e FERRETDB_LISTEN_ADDR=0.0.0.0:27017 .
+```
+
+The command will build and deploy a FerretDB instance, that expects connection on port `27017` using TLS.
+
+After deploying, you can query the service using the provided URL.
+For that, first use `socat` to open a TLS connection (save the returned PID):
+
+```console
+socat tcp-listen:27017,bind=127.0.0.1,fork,reuseaddr openssl:<NAME>.<METRO>.kraft.cloud:27017 &
+```
+
+Now you can query FerretDB using `mongosh`.
+We assume the username is `postgres` and the password is `unikraft`:
+
+```console
+mongosh mongodb://postgres:unikraft@127.0.0.1?authMechanism=PLAIN
+```
+
+To stop the `socat` process, run:
+
+```console
+kill -9 <PID>
+```
+
+## Learn more
+
+- [FerretDB's Documentation](https://docs.ferretdb.io/)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)


### PR DESCRIPTION
Introduce FerretDB to be deployed on KraftCloud. It uses binary-compatibility mode. It uses the `ferretdb:1.2` runtime.

Add:

* `Kraftfile`: build / run rules, including pulling the `ferretdb` image
* `Dockerfile`: placeholder to build / extend filesystem
* `README.md`: document how to use