### PR TITLE
feat(examples): Introduce NGINX + PHP FPM

### DIFF
--- a/nginx-php-fpm/README.md
+++ b/nginx-php-fpm/README.md
@@ -1,0 +1,47 @@
+# NGINX and PHP FPM
+
+[PHP FPM (FastCGI Process Manager)](https://www.php.net/manual/en/install.fpm.php) is a primary PHP FastCGI implementation containing some features (mostly) useful for heavy-loaded sites.
+
+To run PHP FPM, a web server frontend is required, such as [NGINX](https://www.nginx.com/).
+
+To run NGINX and PHP FPM on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository.
+You will create two KraftCloud instances:
+
+1. To create the PHP FPM instance, `cd` into the `php-fpm/` directory and run:
+
+   ```console
+   kraft cloud deploy --name php-fpm -p 9000:9000/tls -M 1024 .
+   ```
+
+   Be sure to use the `php-fpm` as the instance name.
+   It is used by the NGINX configuration.
+
+1. To create the NGINX frontend instance, `cd` into the `nginx/` directory and run:
+
+   ```console
+   kraft cloud deploy --name nginx-uk -p 443:8080 -M 756 .
+   ```
+
+After deploying, you can query the service using the provided URL.
+Two queries can be made:
+
+1. Test the NGINX frontend with a pure HTML query:
+
+   ```
+   curl https://<NAME>.<METRO>.kraft.host/hello.html
+   ```
+
+1. Test the NGINX + PHP FPM service with a PHP query:
+
+   ```
+   curl https://<NAME>.<METRO>.kraft.host/hello.php
+   ```
+
+The reply is an simple HTML "Hello, World!" web page.
+
+## Learn more
+
+- [PHP FPM's Documentation](https://www.php.net/manual/en/install.fpm.php)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/nginx-php-fpm/nginx/Dockerfile
+++ b/nginx-php-fpm/nginx/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:1.25.3-bookworm AS build
+
+# Custom configuration files, including using a single process for Nginx
+COPY ./etc/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY ./etc/nginx/fastcgi_params /etc/nginx/fastcgi_params
+
+# Web root
+COPY ./var/www/html/hello.html ./var/www/html/hello.html
+
+RUN rm /var/log/nginx/error.log
+RUN rm /var/log/nginx/access.log
+RUN touch /var/log/nginx/error.log
+RUN touch /var/log/nginx/access.log

--- a/nginx-php-fpm/nginx/Kraftfile
+++ b/nginx-php-fpm/nginx/Kraftfile
@@ -1,0 +1,8 @@
+spec: v0.6
+
+runtime: base-compat:latest
+#runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/sbin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/nginx-php-fpm/nginx/etc/nginx/fastcgi_params
+++ b/nginx-php-fpm/nginx/etc/nginx/fastcgi_params
@@ -1,0 +1,31 @@
+fastcgi_param  QUERY_STRING       $query_string;
+fastcgi_param  REQUEST_METHOD     $request_method;
+fastcgi_param  CONTENT_TYPE       $content_type;
+fastcgi_param  CONTENT_LENGTH     $content_length;
+
+fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+fastcgi_param  REQUEST_URI        $request_uri;
+fastcgi_param  DOCUMENT_URI       $document_uri;
+fastcgi_param  DOCUMENT_ROOT      $document_root;
+fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+fastcgi_param  REQUEST_SCHEME     $scheme;
+fastcgi_param  HTTPS              $https if_not_empty;
+
+fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+
+fastcgi_param  REMOTE_ADDR        $remote_addr;
+fastcgi_param  REMOTE_PORT        $remote_port;
+fastcgi_param  REMOTE_USER        $remote_user;
+fastcgi_param  SERVER_ADDR        $server_addr;
+fastcgi_param  SERVER_PORT        $server_port;
+fastcgi_param  SERVER_NAME        $server_name;
+
+# PHP only, required if PHP was built with --enable-force-cgi-redirect
+fastcgi_param  REDIRECT_STATUS    200;
+
+fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
+fastcgi_param   PATH_INFO               $fastcgi_path_info;
+fastcgi_param   PATH_TRANSLATED         $document_root$fastcgi_path_info;
+
+#fastcgi_param   HTTPS                   $https;

--- a/nginx-php-fpm/nginx/etc/nginx/nginx.conf
+++ b/nginx-php-fpm/nginx/etc/nginx/nginx.conf
@@ -1,0 +1,66 @@
+worker_processes  1;
+daemon            off;
+master_process    off;
+user root root;
+
+events {
+  worker_connections  64;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  open_file_cache           max=10000 inactive=30s;
+  open_file_cache_min_uses  2;
+  open_file_cache_errors    on;
+
+  error_log stderr;
+  access_log stderr;
+
+  keepalive_timeout     10s;
+  keepalive_requests    10000;
+  send_timeout          10s;
+
+  upstream php {
+    server php-fpm.internal:9000;
+  }
+
+  server {
+    listen              8080;
+    server_name         localhost;
+    root                /var/www/html;
+    index               index.php index.html;
+
+    location = /favicon.ico {
+      log_not_found off;
+      access_log off;
+    }
+
+    location = /robots.txt {
+      allow all;
+      log_not_found off;
+      access_log off;
+    }
+
+    location / {
+           # This is cool because no php is touched for static content.
+           # include the "?$args" part so non-default permalinks doesn't break when using query string
+           try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+      root /var/www/html;
+      #NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+      include fastcgi_params;
+      fastcgi_intercept_errors on;
+      fastcgi_index index.php;
+      fastcgi_pass php;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
+      expires max;
+      log_not_found off;
+    }
+  }
+}

--- a/nginx-php-fpm/nginx/var/www/html/hello.html
+++ b/nginx-php-fpm/nginx/var/www/html/hello.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Hello, World!</title>
+    </head>
+    <body>
+        <p>Hello, World!</p>
+    </body>
+</html>

--- a/nginx-php-fpm/php-fpm/Dockerfile
+++ b/nginx-php-fpm/php-fpm/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.3-fpm-alpine
+
+# Use the default production configuration
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+ADD wrapper.sh /usr/local/bin/wrapper.sh
+ADD hello.php /var/www/html

--- a/nginx-php-fpm/php-fpm/Kraftfile
+++ b/nginx-php-fpm/php-fpm/Kraftfile
@@ -1,0 +1,10 @@
+spec: v0.6
+
+name: php-fpm
+
+runtime: base-compat:latest
+
+rootfs: ./Dockerfile
+
+#cmd: ["/usr/local/bin/wrapper.sh", "/usr/local/bin/docker-entrypoint.sh", "php-fpm"]
+cmd: ["/usr/local/bin/wrapper.sh", "/usr/local/sbin/php-fpm"]

--- a/nginx-php-fpm/php-fpm/hello.php
+++ b/nginx-php-fpm/php-fpm/hello.php
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Hello, World!</title>
+    </head>
+    <body>
+<?php
+    echo "<p>Hello, World!</p>\n";
+?>
+    </body>
+</html>

--- a/nginx-php-fpm/php-fpm/wrapper.sh
+++ b/nginx-php-fpm/php-fpm/wrapper.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+set -e
+
+# Set defaults from offical dockerfile
+if [ -z "$PHP_INI_DIR" ]; then
+    export PHP_INI_DIR=/usr/local/etc/php
+fi
+
+cd /var/www/html
+
+exec "$@"


### PR DESCRIPTION
Introduce PHP FPM (FastCGI Process Manager) with an Nginx frontend. PHP FPM uses the `base-compat` image. NGINX can use bot the `base-compat` (Linux Tinyx) and the `base` (Unikraft) image.

Add:

* `nginx/Kraftfile`: NGINX build / run rules
* `nginx/Dockerfile`: placeholder to extract the NGINX filesystem
* `nginx/{var,etc}/`: NGINX configuration and data files
* `php-fpm/Kraftfile`: NGINX build / run rules
* `php-fpm/Dockerfile`: placeholder to extract the NGINX filesystem
* `php-fpm/hello.php`: simple test PHP file
* `php-fpm/wrapper.sh`: wrapper script to set up the enviroment
* `README.md`: document how to use