### PR TITLE
feat(examples): Introduce .NET

### DIFF
--- a/http-dotnet8.0/Dockerfile
+++ b/http-dotnet8.0/Dockerfile
@@ -1,0 +1,30 @@
+FROM --platform=linux/x86_64 mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+WORKDIR /src
+
+RUN dotnet new console
+RUN rm Program.cs
+COPY ./SimpleHttpServer.cs .
+RUN dotnet build .
+
+FROM scratch
+
+# Binary executable
+COPY --from=build /src/bin/Debug/net8.0 /usr/bin/app
+
+# .NET libraries and confis
+COPY --from=build /usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.4 /usr/share/dotnet/shared/Microsoft.NETCore.App/8.0.4
+COPY --from=build /usr/share/dotnet/host /usr/share/dotnet/host
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/librt.so.1 /lib/x86_64-linux-gnu/librt.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libicuuc.so.72 /lib/x86_64-linux-gnu/libicuuc.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libicudata.so.72 /lib/x86_64-linux-gnu/libicudata.so.72
+COPY --from=build /lib/x86_64-linux-gnu/libicui18n.so.72 /lib/x86_64-linux-gnu/libicui18n.so.72
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/http-dotnet8.0/Kraftfile
+++ b/http-dotnet8.0/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: dotnet
+
+runtime: base-compat:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/app/src"]

--- a/http-dotnet8.0/README.md
+++ b/http-dotnet8.0/README.md
@@ -1,0 +1,14 @@
+# .NET on KraftCloud
+
+To run this example, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+
+To deploy this application on KraftCloud, invoke:
+
+```console
+kraft cloud deploy -p 443:8080 -M 512 .
+```
+
+## Learn more
+
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [How to build `Dockerfile` root filesystems with BuildKit](https://unikraft.org/docs/getting-started/integrations/buildkit)

--- a/http-dotnet8.0/SimpleHttpServer.cs
+++ b/http-dotnet8.0/SimpleHttpServer.cs
@@ -1,0 +1,34 @@
+// https://codingvision.net/c-simple-http-server
+
+using System;
+using System.Net;
+using System.IO;
+using System.Text;
+
+namespace test
+{
+	class SimpleHttpServer
+	{
+		static void Main(string[] args)
+		{
+			HttpListener server = new HttpListener();
+			server.Prefixes.Add("http://*:8080/");
+
+			server.Start();
+			Console.WriteLine("Listening on port 8080 ...");
+
+			while (true)
+			{
+				HttpListenerContext context = server.GetContext();
+				HttpListenerResponse response = context.Response;
+
+				byte[] buffer = Encoding.UTF8.GetBytes("Hello, World!\n");
+				response.ContentLength64 = buffer.Length;
+				response.OutputStream.Write(buffer, 0, buffer.Length);
+
+				context.Response.Close();
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
Introduce a .NET simple HTTP server example to be deployed on KraftCloud. It uses the `base-compat` image.

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: placeholder to extract the filesystem
* `SimpleHttpServer.cs`: HTTP server implementation
* `README.md`: document how to use