### PR TITLE
feat(examples): Add Bun example

### DIFF
--- a/bun/.dockerignore
+++ b/bun/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/bun/.gitignore
+++ b/bun/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/bun/Dockerfile
+++ b/bun/Dockerfile
@@ -1,0 +1,38 @@
+FROM oven/bun:1 AS bun
+
+RUN set -xe; \
+    mv /usr/local/bin/bun /usr/bin/bun; \
+    mkdir /self; \
+    ln -sfn /usr/bin/bun /self/exe
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+      ca-certificates \
+      tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=bun /self /proc/self
+COPY --from=bun /usr/bin/bun /usr/bin/bun
+
+COPY --from=bun /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=bun /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=bun /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=bun /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=bun /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/UTC /usr/share/zoneinfo/UTC
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+COPY ./server.ts /usr/src/server.ts

--- a/bun/Kraftfile
+++ b/bun/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: bun
+
+runtime: base-compat:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/bun", "run", "/usr/src/server.ts"]

--- a/bun/README.md
+++ b/bun/README.md
@@ -1,0 +1,18 @@
+# Bun
+
+[Bun](https://bun.sh/) is an all-in-one toolkit for JavaScript and TypeScript apps.
+
+To run Bun on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud deploy --metro fra0 -p 443:3000 -M 512 .
+```
+
+After deploying, you can query the service using the provided URL.
+
+## Learn more
+
+- [Bun's Documentation](https://bun.sh/docs)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/bun/server.ts
+++ b/bun/server.ts
@@ -1,0 +1,12 @@
+const port = process.env.PORT || 3000;
+
+console.log(
+  `Launching Bun HTTP server on port: ${port}, url: http://0.0.0.0:${port} 🚀`
+);
+
+Bun.serve({
+  port: port,
+  fetch(_request) {
+    return new Response("Hello, World!\n");
+  },
+});


### PR DESCRIPTION
Introduce a Bun example to be deployed on KraftCloud. It uses the `base-compat` image.

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: placeholder to extract the filesystem
* `server.ts`: simple Bun server implementation
* `README.md`: document how to use
* `.dockerignore` / `.gitignore`: ignore generated files