### PR TITLE
feat(examples): Add Flask + MariaDB Compose-based app

### DIFF
--- a/python3.12-flask3.0-mariadb/.dockerignore
+++ b/python3.12-flask3.0-mariadb/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/python3.12-flask3.0-mariadb/Dockerfile
+++ b/python3.12-flask3.0-mariadb/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-bookworm AS base
+
+WORKDIR /app
+
+COPY requirements.txt /app
+
+RUN pip3 install -r requirements.txt --no-cache-dir
+
+FROM scratch
+
+COPY --from=base /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY ./server.py /app/server.py

--- a/python3.12-flask3.0-mariadb/Kraftfile
+++ b/python3.12-flask3.0-mariadb/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: python:3.12
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/python3", "/app/server.py"]

--- a/python3.12-flask3.0-mariadb/README.md
+++ b/python3.12-flask3.0-mariadb/README.md
@@ -1,0 +1,26 @@
+# Flask with MariaDB
+
+[Flask](https://flask.palletsprojects.com/en/3.0.x/) is a micro web framework written in Python.
+
+To run Tyk on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+This example uses a MariaDB back-end.
+Clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud compose up
+```
+
+After deploying, you can query the service using the provided URL.
+
+```console
+curl https://<NAME>.<METRO>.kraft.host/hello
+```
+```text
+{"data":[[6]]}
+```
+
+## Learn more
+
+- [Flask's Documentation](https://flask.palletsprojects.com/en/3.0.x/)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/python3.12-flask3.0-mariadb/compose.yaml
+++ b/python3.12-flask3.0-mariadb/compose.yaml
@@ -1,0 +1,11 @@
+services:
+
+  python:
+    build: .
+    ports:
+      - 443:8080
+    mem_reservation: 512M
+
+  mariadb:
+    image: mariadb:latest
+    mem_reservation: 1024M

--- a/python3.12-flask3.0-mariadb/requirements.txt
+++ b/python3.12-flask3.0-mariadb/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0,<3.1
+mysql-connector-python

--- a/python3.12-flask3.0-mariadb/server.py
+++ b/python3.12-flask3.0-mariadb/server.py
@@ -1,0 +1,45 @@
+from flask import Flask, jsonify
+import mysql.connector
+
+app = Flask(__name__)
+
+db_config = {
+   'host': 'python312-flask30-mariadb-mariadb.internal',
+   'user': 'root',
+   'password': 'unikraft',
+   'database': 'mysql'
+}
+
+def get_data_from_database():
+   try:
+       connection = mysql.connector.connect(**db_config)
+       cursor = connection.cursor()
+
+       # Replace this query with your actual SQL query
+       query = "SELECT count(*) FROM user;"
+       cursor.execute(query)
+
+       data = cursor.fetchall()
+
+       return data
+
+   except Exception as e:
+       print(f"Error: {e}")
+       return None
+
+   finally:
+       if connection.is_connected():
+           cursor.close()
+           connection.close()
+
+@app.route('/')
+def get_data():
+   data = get_data_from_database()
+
+   if data is not None:
+       return jsonify({'data': data})
+   else:
+       return jsonify({'error': 'Failed to retrieve data from the database'})
+
+if __name__ == '__main__':
+   app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
Add Flask application backed by MariaDB. Build and run using `kraft cloud compose`.