### PR TITLE
feat(examples): Add HTTP server in Elixir

### DIFF
--- a/http-elixir1.16/.dockerignore
+++ b/http-elixir1.16/.dockerignore
@@ -1,0 +1,29 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+server-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# Unikraft build files.
+/.unikraft/

--- a/http-elixir1.16/.formatter.exs
+++ b/http-elixir1.16/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/http-elixir1.16/.gitignore
+++ b/http-elixir1.16/.gitignore
@@ -1,0 +1,29 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+server-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/
+
+# Unikraft build files.
+/.unikraft/

--- a/http-elixir1.16/Dockerfile
+++ b/http-elixir1.16/Dockerfile
@@ -1,0 +1,73 @@
+FROM elixir:1.16.2-slim as build
+
+WORKDIR /src
+
+COPY . .
+
+RUN mix deps.get
+
+RUN mix compile
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+      ca-certificates \
+      tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/UTC /usr/share/zoneinfo/UTC
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libgcc_s.so.1 \
+                  /lib/x86_64-linux-gnu/libm.so.6 \
+                  /lib/x86_64-linux-gnu/libsctp.so.1 \
+                  /lib/x86_64-linux-gnu/libstdc++.so.6 \
+                  /lib/x86_64-linux-gnu/libtinfo.so.6 \
+                  /lib/x86_64-linux-gnu/libcrypto.so.3 \
+                  /lib/x86_64-linux-gnu/libselinux.so.1 \
+                  /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libpcre2-8.so.0 \
+                  /lib/x86_64-linux-gnu/
+
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+COPY --from=build /usr/local/lib/erlang /usr/local/lib/erlang
+COPY --from=build /usr/local/lib/elixir /usr/local/lib/elixir
+
+COPY --from=build /usr/lib/locale /usr/lib/locale
+
+COPY --from=build /usr/local/bin /usr/local/bin
+
+COPY --from=build /usr/bin/dirname \
+                  /usr/bin/basename \
+                  /usr/bin/readlink \
+                  /usr/bin/env \
+                  /usr/bin/
+
+COPY --from=build /bin/rm \
+                  /bin/mknod \
+                  /bin/bash \
+                  /bin/sh \
+                  /bin/
+
+COPY --from=build /root /root
+
+COPY --from=build /src/deps /src/deps
+COPY --from=build /src/_build /src/_build
+COPY --from=build /src/lib /src/lib
+COPY --from=build /src/mix.exs /src/mix.exs
+COPY --from=build /src/mix.lock /src/mix.lock
+
+COPY ./wrapper.sh /usr/bin/wrapper.sh

--- a/http-elixir1.16/Kraftfile
+++ b/http-elixir1.16/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: elixir
+
+runtime: base-compat:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/wrapper.sh", "/usr/local/bin/mix", "run", "--no-halt"]

--- a/http-elixir1.16/README.md
+++ b/http-elixir1.16/README.md
@@ -1,0 +1,24 @@
+# Simple Elixir HTTP Server
+
+This is a simple HTTP server written in the Elixir programming language.
+The initial contents of this example were created by using the command:
+
+```console
+mix new --app server . --sup
+```
+
+To run this example on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud deploy --metro fra0 -p 443:3000 -M 1024 .
+```
+
+The command will build and deploy the implementation in `lib/`.
+After deploying, you can query the service using the provided URL.
+
+## Learn more
+
+- [Elixir's Documentation](https://elixir-lang.org/docs.html)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-elixir1.16/lib/server.ex
+++ b/http-elixir1.16/lib/server.ex
@@ -1,0 +1,20 @@
+defmodule Server do
+  @moduledoc """
+  A Plug that always responds with a string
+  """
+  import Plug.Conn
+
+  def init(options) do
+    options
+  end
+
+  @doc """
+  Simple route that returns a string
+  """
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> send_resp(200, "Hello, World!\n")
+  end
+end

--- a/http-elixir1.16/lib/server/application.ex
+++ b/http-elixir1.16/lib/server/application.ex
@@ -1,0 +1,21 @@
+defmodule Server.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    children = [
+      # Starts a worker by calling: Server.Worker.start_link(arg)
+      # {Server.Worker, arg}
+      {Plug.Cowboy, scheme: :http, plug: Server, options: [port: 3000]}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: Server.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/http-elixir1.16/mix.exs
+++ b/http-elixir1.16/mix.exs
@@ -1,0 +1,30 @@
+defmodule Server.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :server,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Server.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:plug_cowboy, "~> 2.0"}
+    ]
+  end
+end

--- a/http-elixir1.16/test/server_test.exs
+++ b/http-elixir1.16/test/server_test.exs
@@ -1,0 +1,8 @@
+defmodule ServerTest do
+  use ExUnit.Case
+  doctest Server
+
+  test "greets the world" do
+    assert Server.hello() == :world
+  end
+end

--- a/http-elixir1.16/test/test_helper.exs
+++ b/http-elixir1.16/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/http-elixir1.16/wrapper.sh
+++ b/http-elixir1.16/wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+cd /src
+export PATH=/usr/bin:/usr/local/bin
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+export LANGUAGE=C.UTF-8
+export MIX_HOME=/root/.mix
+exec $@


### PR DESCRIPTION
Introduce HTTP server written in Elixir. It uses the base-compat (Tinyx) image.

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: placeholder to extract the filesystem
* `lib/`, `mix.exs`, `.formatter.exs`, `test/`: Elixir files
* `wrapper.sh`: wrapper script to start the server
* `README.md`: document how to use
* `.dockerignore` / `.gitignore`: ignore generated files