### PR TITLE
feat(examples): Add Puppeteer example

### DIFF
--- a/puppeteer/.dockerignore
+++ b/puppeteer/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/puppeteer/.gitignore
+++ b/puppeteer/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/puppeteer/.puppeteerrc.cjs
+++ b/puppeteer/.puppeteerrc.cjs
@@ -1,0 +1,4 @@
+const {join} = require('path');
+module.exports = {
+  cacheDirectory: join('/root', '.cache', 'puppeteer')
+};

--- a/puppeteer/Dockerfile
+++ b/puppeteer/Dockerfile
@@ -1,0 +1,199 @@
+FROM debian:bookworm AS build
+
+RUN set -xe; \
+    apt-get -yqq update; \
+    apt-get -yqq install \
+        libcups2 \
+        libnss3 \
+        libatk1.0-0 \
+        libnspr4 \
+        libpango1.0-0 \
+        libasound2 \
+        libatspi2.0-0 \
+        libxdamage1 \
+        libatk-bridge2.0-0 \
+        libxkbcommon0; \
+    apt-get -yqq install \
+        git \
+        nodejs \
+        npm \
+    ;
+
+WORKDIR /src
+
+RUN npm install puppeteer
+
+RUN mkdir /home/tmp
+
+FROM scratch
+
+# Create required directories.
+COPY --from=build /home/tmp /tmp
+
+# Chrome binary
+COPY --from=build /root/.cache/puppeteer/chrome /root/.cache/puppeteer/chrome
+
+# Chrome libraries
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 \
+                  /lib/x86_64-linux-gnu/libpthread.so.0 \
+                  /lib/x86_64-linux-gnu/libgobject-2.0.so.0 \
+                  /lib/x86_64-linux-gnu/libglib-2.0.so.0 \
+                  /lib/x86_64-linux-gnu/libnss3.so \
+                  /lib/x86_64-linux-gnu/libnssutil3.so \
+                  /lib/x86_64-linux-gnu/libsmime3.so \
+                  /lib/x86_64-linux-gnu/libnspr4.so \
+                  /lib/x86_64-linux-gnu/libatk-1.0.so.0 \
+                  /lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0 \
+                  /lib/x86_64-linux-gnu/libcups.so.2 \
+                  /lib/x86_64-linux-gnu/libgio-2.0.so.0 \
+                  /lib/x86_64-linux-gnu/libdrm.so.2 \
+                  /lib/x86_64-linux-gnu/libdbus-1.so.3 \
+                  /lib/x86_64-linux-gnu/libexpat.so.1 \
+                  /lib/x86_64-linux-gnu/libxcb.so.1 \
+                  /lib/x86_64-linux-gnu/libxkbcommon.so.0 \
+                  /lib/x86_64-linux-gnu/libatspi.so.0 \
+                  /lib/x86_64-linux-gnu/libm.so.6 \
+                  /lib/x86_64-linux-gnu/libX11.so.6 \
+                  /lib/x86_64-linux-gnu/libXcomposite.so.1 \
+                  /lib/x86_64-linux-gnu/libXdamage.so.1 \
+                  /lib/x86_64-linux-gnu/libXext.so.6 \
+                  /lib/x86_64-linux-gnu/libXfixes.so.3 \
+                  /lib/x86_64-linux-gnu/libXrandr.so.2 \
+                  /lib/x86_64-linux-gnu/libgbm.so.1 \
+                  /lib/x86_64-linux-gnu/libpango-1.0.so.0 \
+                  /lib/x86_64-linux-gnu/libcairo.so.2 \
+                  /lib/x86_64-linux-gnu/libasound.so.2 \
+                  /lib/x86_64-linux-gnu/libgcc_s.so.1 \
+                  /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libffi.so.8 \
+                  /lib/x86_64-linux-gnu/libpcre2-8.so.0 \
+                  /lib/x86_64-linux-gnu/libplc4.so \
+                  /lib/x86_64-linux-gnu/libplds4.so \
+                  /lib/x86_64-linux-gnu/libgssapi_krb5.so.2 \
+                  /lib/x86_64-linux-gnu/libavahi-common.so.3 \
+                  /lib/x86_64-linux-gnu/libavahi-client.so.3 \
+                  /lib/x86_64-linux-gnu/libgnutls.so.30 \
+                  /lib/x86_64-linux-gnu/libz.so.1 \
+                  /lib/x86_64-linux-gnu/libgmodule-2.0.so.0 \
+                  /lib/x86_64-linux-gnu/libmount.so.1 \
+                  /lib/x86_64-linux-gnu/libselinux.so.1 \
+                  /lib/x86_64-linux-gnu/libsystemd.so.0 \
+                  /lib/x86_64-linux-gnu/libXau.so.6 \
+                  /lib/x86_64-linux-gnu/libXdmcp.so.6 \
+                  /lib/x86_64-linux-gnu/libXi.so.6 \
+                  /lib/x86_64-linux-gnu/libXrender.so.1 \
+                  /lib/x86_64-linux-gnu/libwayland-server.so.0 \
+                  /lib/x86_64-linux-gnu/libfribidi.so.0 \
+                  /lib/x86_64-linux-gnu/libthai.so.0 \
+                  /lib/x86_64-linux-gnu/libharfbuzz.so.0 \
+                  /lib/x86_64-linux-gnu/libpixman-1.so.0 \
+                  /lib/x86_64-linux-gnu/libfontconfig.so.1 \
+                  /lib/x86_64-linux-gnu/libfreetype.so.6 \
+                  /lib/x86_64-linux-gnu/libpng16.so.16 \
+                  /lib/x86_64-linux-gnu/libxcb-shm.so.0 \
+                  /lib/x86_64-linux-gnu/libxcb-render.so.0 \
+                  /lib/x86_64-linux-gnu/libkrb5.so.3 \
+                  /lib/x86_64-linux-gnu/libk5crypto.so.3 \
+                  /lib/x86_64-linux-gnu/libcom_err.so.2 \
+                  /lib/x86_64-linux-gnu/libkrb5support.so.0 \
+                  /lib/x86_64-linux-gnu/libp11-kit.so.0 \
+                  /lib/x86_64-linux-gnu/libidn2.so.0 \
+                  /lib/x86_64-linux-gnu/libunistring.so.2 \
+                  /lib/x86_64-linux-gnu/libtasn1.so.6 \
+                  /lib/x86_64-linux-gnu/libnettle.so.8 \
+                  /lib/x86_64-linux-gnu/libhogweed.so.6 \
+                  /lib/x86_64-linux-gnu/libgmp.so.10 \
+                  /lib/x86_64-linux-gnu/libblkid.so.1 \
+                  /lib/x86_64-linux-gnu/libcap.so.2 \
+                  /lib/x86_64-linux-gnu/libgcrypt.so.20 \
+                  /lib/x86_64-linux-gnu/liblzma.so.5 \
+                  /lib/x86_64-linux-gnu/libzstd.so.1 \
+                  /lib/x86_64-linux-gnu/liblz4.so.1 \
+                  /lib/x86_64-linux-gnu/libbsd.so.0 \
+                  /lib/x86_64-linux-gnu/libdatrie.so.1 \
+                  /lib/x86_64-linux-gnu/libgraphite2.so.3 \
+                  /lib/x86_64-linux-gnu/libbrotlidec.so.1 \
+                  /lib/x86_64-linux-gnu/libkeyutils.so.1 \
+                  /lib/x86_64-linux-gnu/libresolv.so.2 \
+                  /lib/x86_64-linux-gnu/libgpg-error.so.0 \
+                  /lib/x86_64-linux-gnu/libmd.so.0 \
+                  /lib/x86_64-linux-gnu/libbrotlicommon.so.1 \
+                  /lib/x86_64-linux-gnu/
+
+# Other Chrome-related libraries
+COPY --from=build /usr/lib/x86_64-linux-gnu/libfreebl3.so \
+                  /usr/lib/x86_64-linux-gnu/libfreeblpriv3.so \
+                  /usr/lib/x86_64-linux-gnu/libSM.so.6 \
+                  /usr/lib/x86_64-linux-gnu/libsoftokn3.so \
+                  /usr/lib/x86_64-linux-gnu/libsqlite3.so.0 \
+                  /usr/lib/x86_64-linux-gnu/libudev.so.1 \
+                  /usr/lib/x86_64-linux-gnu/
+
+# Node binary
+COPY --from=build /usr/bin/node /usr/local/bin/node
+
+# System libraries
+COPY --from=build /lib/x86_64-linux-gnu/libnode.so.108 \
+                  /lib/x86_64-linux-gnu/libc.so.6 \
+                  /lib/x86_64-linux-gnu/libz.so.1 \
+                  /lib/x86_64-linux-gnu/libuv.so.1 \
+                  /lib/x86_64-linux-gnu/libbrotlidec.so.1 \
+                  /lib/x86_64-linux-gnu/libbrotlienc.so.1 \
+                  /lib/x86_64-linux-gnu/libcares.so.2 \
+                  /lib/x86_64-linux-gnu/libnghttp2.so.14 \
+                  /lib/x86_64-linux-gnu/libcrypto.so.3 \
+                  /lib/x86_64-linux-gnu/libssl.so.3 \
+                  /lib/x86_64-linux-gnu/libicui18n.so.72 \
+                  /lib/x86_64-linux-gnu/libicuuc.so.72 \
+                  /lib/x86_64-linux-gnu/libstdc++.so.6 \
+                  /lib/x86_64-linux-gnu/libm.so.6 \
+                  /lib/x86_64-linux-gnu/libgcc_s.so.1 \
+                  /lib/x86_64-linux-gnu/libpthread.so.0 \
+                  /lib/x86_64-linux-gnu/libdl.so.2 \
+                  /lib/x86_64-linux-gnu/libbrotlicommon.so.1 \
+                  /lib/x86_64-linux-gnu/libicudata.so.72 \
+                  /lib/x86_64-linux-gnu/librt.so.1 \
+                  /lib/x86_64-linux-gnu/
+
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# Dbus and system files
+COPY --from=build /usr/lib/dbus-1.0 /usr/lib/dbus-1.0
+COPY --from=build /usr/lib/systemd /usr/lib/systemd
+COPY --from=build /usr/lib/tmpfiles.d /usr/lib/tmpfiles.d
+COPY --from=build /usr/lib/sysusers.d /usr/lib/sysusers.d
+COPY --from=build /usr/lib/sysctl.d /usr/lib/sysctl.d
+
+# Data files
+COPY --from=build /usr/share/fonts /usr/share/fonts
+COPY --from=build /usr/share/nodejs /usr/share/nodejs
+
+COPY --from=build /run /run
+
+# Distro definition
+COPY --from=build /etc/os-release /etc/os-release
+COPY --from=build /usr/lib/os-release /usr/lib/os-release
+
+# Configuration files
+COPY --from=build /etc /etc
+
+
+# Node modules, including Puppeteer
+COPY --from=build /src/node_modules /src/node_modules
+
+# Actual source code used by Puppeteer.
+COPY ./pdf.js /src/pdf.js
+
+COPY ./wrapper.sh /usr/bin/wrapper.sh
+
+COPY ./.puppeteerrc.cjs /src/.puppeteerrc.cjs
+
+COPY --from=build /lib/x86_64-linux-gnu/libselinux.so.1 /lib/x86_64-linux-gnu/libselinux.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
+COPY --from=build /bin/rm /bin/rm
+COPY --from=build /bin/mknod /bin/mknod
+
+COPY --from=build /bin/bash /bin/bash
+COPY --from=build /bin/sh /bin/sh

--- a/puppeteer/Dockerfile.full
+++ b/puppeteer/Dockerfile.full
@@ -1,0 +1,26 @@
+FROM debian:bookworm AS build
+
+RUN set -xe; \
+    apt-get -yqq update; \
+    apt-get -yqq install \
+        libcups2 \
+        libnss3 \
+        libatk1.0-0 \
+        libnspr4 \
+        libpango1.0-0 \
+        libasound2 \
+        libatspi2.0-0 \
+        libxdamage1 \
+        libatk-bridge2.0-0 \
+        libxkbcommon0; \
+    apt-get -yqq install \
+        git \
+        nodejs \
+        npm \
+    ;
+
+WORKDIR /src
+
+RUN npm install puppeteer
+
+COPY ./pdf.js /src/pdf.js

--- a/puppeteer/Kraftfile
+++ b/puppeteer/Kraftfile
@@ -1,0 +1,7 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/wrapper.sh", "/usr/local/bin/node", "/src/pdf.js"]

--- a/puppeteer/README.md
+++ b/puppeteer/README.md
@@ -1,0 +1,27 @@
+# Puppeteer
+
+[Puppeteer](https://pptr.dev/) is a Node.js library which provides a high-level API to control browsers, including the option to run them headless (no UI).
+
+To run Puppeteer on KraftCloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud deploy --metro fra0 -M 4096 .
+```
+
+The command will deploy the files in the current directory.
+It will run the `pdf.js` example.
+Note that this example won't give you access the generated PDF file.
+To be able to extract the result, you will have to create a service-like implementation on top of the Puppeteer API that can be queried remotely.
+
+To check it worked, use:
+
+```console
+kraft cloud inst logs $(kraft cloud inst ls | grep puppeteer | cut -d ' ' -f 1)
+```
+
+## Learn more
+
+- [Puppeteer's Documentation](is a Node.js library which provides a high-level API to control)
+- [KraftCloud's Documentation](https://docs.kraft.cloud)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/puppeteer/pdf.js
+++ b/puppeteer/pdf.js
@@ -1,0 +1,31 @@
+/**
+ * @name pdf
+ *
+ * @desc Renders a PDF of the Puppeteer API spec. This is a pretty long page and will generate a nice, A4 size multi-page PDF.
+ *
+ * @see {@link https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pdf}
+ */
+
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({
+          args: ['--no-sandbox'],
+          timeout: 0,
+          headless: "new",
+  });
+  const page = await browser.newPage()
+
+  // 1. Create PDF from URL
+  await page.goto('https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pdf')
+  await page.pdf({ path: 'api.pdf', format: 'A4' })
+
+  // 2. Create PDF from static HTML
+  const htmlContent = `<body>
+  <h1>An example static HTML to PDF</h1>
+  </body>`
+  await page.setContent(htmlContent)
+  await page.pdf({ path: 'html.pdf', format: 'A4' })
+
+  await browser.close()
+})()

--- a/puppeteer/wrapper.sh
+++ b/puppeteer/wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -e
+
+export HOME=/root
+cd /src
+exec "$@"


### PR DESCRIPTION
Introduce a Puppeteer example to be deployed on KraftCloud. It uses the `base-compat:latest` image.

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: placeholder to extract the filesystem
* `pdf.js`: implementation of a PDF converter
* `README.md`: document how to use
* `.dockerignore` / `.gitignore`: ignore generated files