### PR TITLE
feat(examples): Introduce Restate

### DIFF
--- a/restate-1.0.2/Dockerfile
+++ b/restate-1.0.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.io/restatedev/restate:1.0.2
+COPY ./config.yml restate.yaml

--- a/restate-1.0.2/Kraftfile
+++ b/restate-1.0.2/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.6
+
+name: restate
+
+runtime: base:latest
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/local/bin/restate-server"]

--- a/restate-1.0.2/README.md
+++ b/restate-1.0.2/README.md
@@ -1,0 +1,21 @@
+# Restate
+
+[Restate](ihttps://restate.dev/) is the simplest way to write resilient workflows, event-driven applications, and async tasks.
+
+To run Restate on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and create a volume and then a Restate instance:
+
+```console
+kraft cloud volume create --metro fra0 --name restate --size 1024
+kraft cloud deploy --metro fra0 -p 443:8080 -M 512 -v restate:/var/lib/restate
+```
+
+The command will deploy Restate using the configuration file `conf.yml`.
+
+After deploying, you can query the service using the provided URL.
+
+## Learn more
+
+- [Restate's Documentation](https://docs.restate.dev/)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/restate-1.0.2/config.yml
+++ b/restate-1.0.2/config.yml
@@ -1,0 +1,14 @@
+meta:
+  storage_path: /var/lib/restate/meta
+worker:
+  invoker:
+    retry_policy:
+      initial_interval: 50ms
+      max_attempts: 3
+  storage_rocksdb:
+    path: /var/lib/restate/rocksdb
+bifrost:
+  default_provider: File
+  providers_config:
+    File:
+      path: /var/lib/restate/bifrost


### PR DESCRIPTION
Introduce Restate. It makes use of the `base` runtime. Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: placeholder to extract the filesystem
* `README.md`: document how to use
* `config.yml`: Restate configuration file