### PR TITLE
deps(spin-wagi-http): Bump spin-sdk from v2.1.0 to v2.7.0

### DIFF
--- a/spin-wagi-http/Dockerfile
+++ b/spin-wagi-http/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.75.0-bookworm AS spin-devenv
 
-ARG SPIN_VERSION=2.1.0
+ARG SPIN_VERSION=2.7.0
 
 WORKDIR /spin
 

--- a/spin-wagi-http/goodbye-rust/Cargo.lock
+++ b/spin-wagi-http/goodbye-rust/Cargo.lock
@@ -366,8 +366,8 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "2.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.1.0#4ca3a56153a1d85b176ffd05804a476a59deb4ea"
+version = "2.7.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.1.0#a11151706449fa1ba39bfe96597fe1041438dc67"
 dependencies = [
  "anyhow",
  "bytes",
@@ -379,8 +379,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "2.1.0"
-source = "git+https://github.com/fermyon/spin?tag=v2.1.0#4ca3a56153a1d85b176ffd05804a476a59deb4ea"
+version = "2.7.0"
+source = "git+https://github.com/fermyon/spin?tag=v2.7.0#a11151706449fa1ba39bfe96597fe1041438dc67"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/spin-wagi-http/goodbye-rust/Cargo.toml
+++ b/spin-wagi-http/goodbye-rust/Cargo.toml
@@ -14,6 +14,6 @@ bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v2.1.0" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v2.7.0" }
 
 [workspace]


### PR DESCRIPTION
Signedoff-by: Alexander Jung <alex@unikraft.cloud>
