### PR TITLE
feat(examples): Add Java 21 example

### DIFF
--- a/http-java21-compat/Dockerfile
+++ b/http-java21-compat/Dockerfile
@@ -1,0 +1,51 @@
+# Stage 1: Build environment
+FROM ubuntu:24.04 AS build
+
+# Install necessary packages
+RUN set -xe ; \
+    apt -yqq update ; \
+    apt -yqq install default-jre default-jdk unzip
+
+RUN ldconfig /usr/lib/jvm/java-21-openjdk-amd64/lib/
+
+WORKDIR /src
+
+COPY ./SimpleHttpServer.java /src/SimpleHttpServer.java
+
+RUN javac SimpleHttpServer.java
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+      ca-certificates \
+      tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/UTC /usr/share/zoneinfo/UTC
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+COPY --from=build /usr/lib/jvm/java-21-openjdk-amd64/ /usr/lib/jvm/java-21-openjdk-amd64/
+COPY --from=build /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/cacerts
+
+COPY --from=build /etc/java-21-openjdk/security/ /etc/java-21-openjdk/security/
+
+COPY --from=build /src/SimpleHttpServer.class /usr/src/SimpleHttpServer.class

--- a/http-java21-compat/Kraftfile
+++ b/http-java21-compat/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "idle"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "-classpath", "/usr/src/", "SimpleHttpServer"]

--- a/http-java21-compat/README.md
+++ b/http-java21-compat/README.md
@@ -1,0 +1,20 @@
+# Simple Java 21 HTTP Server
+
+This is a simple HTTP server written in the [Java](https://www.java.com/en/) programming language.
+
+To run this example on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```
+kraft cloud deploy --metro fra0 -p 443:8080 -M 1024Mi .
+```
+
+The command will build and deploy the `SimpleHTTPServer.java` source code file.
+
+After deploying, you can query the service using the provided URL.
+
+## Learn more
+
+- [Java's Documentation](https://docs.oracle.com/en/java/)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/http-java21-compat/SimpleHttpServer.java
+++ b/http-java21-compat/SimpleHttpServer.java
@@ -1,0 +1,29 @@
+// https://www.logicbig.com/tutorials/core-java-tutorial/http-server/http-server-basic.html
+
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class SimpleHttpServer {
+    private static final int listenPort = 8080;
+
+    public static void main(String[] args) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(listenPort), 0);
+        HttpContext context = server.createContext("/");
+        context.setHandler(SimpleHttpServer::handleRequest);
+        System.out.println("Waiting for HTTP connections on port " + listenPort + " ...");
+        server.start();
+    }
+
+    private static void handleRequest(HttpExchange exchange) throws IOException {
+        String response = "Hello, World!\n";
+        exchange.sendResponseHeaders(200, response.getBytes().length); // response code and length
+        OutputStream os = exchange.getResponseBody();
+        os.write(response.getBytes());
+        os.close();
+    }
+
+}


### PR DESCRIPTION
Introduce a Java 21 example to be deployed on KraftCloud. It uses the `base-compat:latest` image.

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: placeholder to extract the filesystem
* `SimpleHttpServer.java`: simple Java HTTP server
* `README.md`: document how to use