### PR TITLE
fix(postgres): Clean up and add `tzdata` and `ca-certificates`

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,15 +1,37 @@
 FROM postgres:16.2-alpine AS base
 
 FROM base AS ext-build
-RUN apk add --no-cache gcc make musl-dev llvm15-dev clang15 unzip
+
+RUN set -xe; \
+    apk add --no-cache \
+      gcc \
+      ca-certificates \
+      make \
+      tzdata \
+      musl-dev \
+      llvm15-dev \
+      clang15 \
+      unzip
+
 ADD https://github.com/kraftcloud/pg_ukc_scaletozero/archive/refs/heads/stable.zip /tmp/src.zip
-RUN mkdir /src && \
-    unzip /tmp/src.zip -d /tmp/extract && \
+
+RUN set -xe; \
+    mkdir /src; \
+    unzip /tmp/src.zip -d /tmp/extract; \
     mv /tmp/extract/pg_ukc_scaletozero-*/* /src
-RUN cd /src && \
-    make && \
+
+WORKDIR /src
+
+RUN set -xe; \
+    make; \
     make install DESTDIR=/out
 
 FROM base
+
+COPY --from=ext-build /usr/share/zoneinfo/UTC /usr/share/zoneinfo/UTC
+COPY --from=ext-build /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=ext-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=ext-build /out/usr/local/lib/postgresql/pg_ukc_scaletozero.so /usr/local/lib/postgresql/pg_ukc_scaletozero.so
+
 ADD wrapper.sh /usr/local/bin/wrapper.sh
+


### PR DESCRIPTION
This commit fixes an issue where time zone data was not present in the official Postgres image or latest CA certificates.  This commit tidies up the `Dockerfile` to make its syntax more alike with others in this repository and adds the aforementioned packages.  This latter solves connection issues which may occur from connecting to the Postgres instance from an IDE or database manager tool.

