### PR TITLE
feat(examples): Add Tyk example using base image

### DIFF
--- a/tyk-base/.dockerignore
+++ b/tyk-base/.dockerignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/tyk-base/.gitignore
+++ b/tyk-base/.gitignore
@@ -1,0 +1,1 @@
+/.unikraft/

--- a/tyk-base/Dockerfile
+++ b/tyk-base/Dockerfile
@@ -1,0 +1,44 @@
+FROM --platform=linux/x86_64 golang:1.21.3-bookworm AS build
+
+ARG TYK_VERSION=5.2.6
+
+WORKDIR /tyk
+
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    set -xe; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+      git; \
+    git clone --depth=1 --branch v${TYK_VERSION} https://github.com/TykTechnologies/tyk /tyk; \
+    go build  \
+      -buildmode=pie \
+      -ldflags "-linkmode external -extldflags -static-pie" \
+      -tags netgo;
+
+FROM alpine:3 AS sys
+
+RUN set -xe; \
+    mkdir -p /target/etc; \
+    mkdir -p /blank; \
+    apk --no-cache add \
+      ca-certificates \
+      tzdata \
+    ; \
+    update-ca-certificates; \
+    ln -sf /usr/share/zoneinfo/Etc/UTC /target/etc/localtime; \
+    echo "Etc/UTC" > /target/etc/timezone;
+
+
+FROM scratch
+
+COPY --from=sys /target/etc /etc
+COPY --from=sys /usr/share/zoneinfo/UTC /usr/share/zoneinfo/UTC
+COPY --from=sys /usr/share/zoneinfo/Etc/UTC /usr/share/zoneinfo/Etc/UTC
+COPY --from=sys /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=sys /blank /tmp
+
+COPY --from=build /tyk/tyk /usr/bin/tyk
+COPY --from=build /tyk/templates /tyk/templates
+
+COPY ./rootfs/ /

--- a/tyk-base/Kraftfile
+++ b/tyk-base/Kraftfile
@@ -1,0 +1,13 @@
+spec: v0.6
+
+runtime: base:latest
+#runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "idle"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/tyk", "start", "--conf", "/etc/tyk.conf"]

--- a/tyk-base/README.md
+++ b/tyk-base/README.md
@@ -1,0 +1,26 @@
+# Tyk
+
+[Tyk](https://tyk.io/) is an API gateway and management platform.
+
+To run Tyk on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli).
+Then clone this examples repository and `cd` into this directory, and invoke:
+
+```console
+kraft cloud compose up
+```
+
+After deploying, you can query the service using the provided URL.
+Use the `/hello` path after the URL, such as below:
+
+```console
+curl https://<NAME>.<METRO>.kraft.host/hello
+```
+```text
+{"status":"pass","version":"v5.3.0-dev","description":"Tyk GW","details":{"redis":{"status":"pass","componentType":"datastore","time":"2024-04-30T10:37:29Z"}}}
+```
+
+## Learn more
+
+- [Tyk's Documentation](https://tyk.io/docs/)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)

--- a/tyk-base/compose.yaml
+++ b/tyk-base/compose.yaml
@@ -1,0 +1,11 @@
+services:
+
+  tyk:
+    build: .
+    ports:
+      - 443:8080
+    #mem_reservation: 512M
+
+  redis:
+    image: redis:latest
+    mem_reservation: 512M

--- a/tyk-base/rootfs/etc/tyk.conf
+++ b/tyk-base/rootfs/etc/tyk.conf
@@ -1,0 +1,38 @@
+{
+  "listen_address": "",
+  "listen_port": 8080,
+  "secret": "352d20ee67be67f6340b4c0605b044b7",
+  "template_path": "/tyk/templates",
+  "use_db_app_configs": false,
+  "app_path": "/opt/tyk-gateway/apps",
+  "middleware_path": "/opt/tyk-gateway/middleware",
+  "storage": {
+    "type": "redis",
+    "host": "tyk-redis.internal",
+    "port": 6379,
+    "username": "",
+    "password": "",
+    "database": 0,
+    "optimisation_max_idle": 2000,
+    "optimisation_max_active": 4000
+  },
+  "enable_analytics": false,
+  "analytics_config": {
+    "type": "",
+    "ignored_ips": []
+  },
+  "dns_cache": {
+    "enabled": false,
+    "ttl": 3600,
+    "check_interval": 60
+  },
+  "allow_master_keys": false,
+  "policies": {
+    "policy_source": "file"
+  },
+  "hash_keys": true,
+  "hash_key_function": "murmur64",
+  "suppress_redis_signal_reload": false,
+  "force_global_session_lifetime": false,
+  "max_idle_connections_per_host": 500
+}


### PR DESCRIPTION
Introduce a Tyk example to be deployed on Unikraft Cloud using the `base` (or `base-compat` image)

Add:

* `Kraftfile`: build / run rules
* `Dockerfile`: build the Tyk application filesystem
* `rootfs/etc/tyk.conf`: a simple Tyk configuration file
* `README.md`: document how to use
* `.dockerignore` / `.gitignore`: ignore generated files