### PR TITLE
Add nginx-flask-mongo compose full-stack example

### DIFF
--- a/nginx-flask-mongo/README.md
+++ b/nginx-flask-mongo/README.md
@@ -1,0 +1,41 @@
+# Flask with MongoDB
+
+[Flask](https://flask.palletsprojects.com/en/stable/) is a lightweight WSGI web application framework in Python, and [MongoDB](https://www.mongodb.com/) is a NoSQL database that stores data in JSON-like documents.
+
+**Credits**: This example is based on this [Awesome Compose example](https://github.com/docker/awesome-compose/tree/master/nginx-flask-mongo).
+
+## Deployment
+
+This example uses a [`compose.yaml`](compose.yaml) file to define the Nginx, Flask, and MongoDB services.
+
+To run it on Unikraft Cloud, first [install the `kraft` CLI tool](https://unikraft.org/docs/cli). Make sure you have an active account on Unikraft Cloud (UKC) and that you have authenticated your CLI with your UKC account.
+
+```bash
+export UKC_TOKEN=<your-unikraft-cloud-access-token>
+export UKC_METRO=fra0
+```
+
+Then `cd` into [this](.) directory, and invoke:
+
+```bash
+kraft cloud compose up
+```
+
+The Flask server is exposed through Nginx. To get the public URL of the deployed application, run:
+
+```bash
+kraft cloud instance get nginx
+```
+
+and look for the `fqdn` field in the output.
+
+## Learn more
+
+- [Flask Documentation](https://flask.palletsprojects.com/en/stable/)
+- [MongoDB Documentation](https://www.mongodb.com/docs/)
+- [Nginx Documentation](https://nginx.org/en/docs/)
+- [Awesome Compose](https://github.com/docker/awesome-compose)
+- [Unikraft Cloud's Documentation](https://unikraft.cloud/docs/)
+- [Building `Dockerfile` Images with `Buildkit`](https://unikraft.org/guides/building-dockerfile-images-with-buildkit)
+- [Deploying with Compose Files](https://unikraft.cloud/docs/guides/features/compose/)
+- [Creating tunnels](https://unikraft.cloud/docs/guides/features/tunnel/)

--- a/nginx-flask-mongo/compose.yaml
+++ b/nginx-flask-mongo/compose.yaml
@@ -1,0 +1,41 @@
+services:
+  web:
+    container_name: nginx
+    build: ./nginx
+    mem_reservation: 512M
+    environment:
+      # Dockerfile env
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - NGINX_VERSION=1.29.0
+      - PKG_RELEASE=1
+      - DYNPKG_RELEASE=1
+      - NJS_VERSION=0.9.0
+      - NJS_RELEASE=1
+    ports:
+      - 443:80
+
+  backend:
+    container_name: backend
+    build: ./flask
+    mem_reservation: 1024M
+    environment:
+      - FLASK_SERVER_PORT=9091
+      - MONGO_SERVER_URL=mongo.internal:27017
+      # Dockerfile env
+      - PATH=/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app
+      - LANG=C.UTF-8
+      - GPG_KEY=7169605F62C751356D054A26A821E680E5FA6305
+      - PYTHON_VERSION=3.12.11
+      - PYTHON_SHA256=c30bb24b7f1e9a19b11b55a546434f74e739bb4c271a3e3a80ff4380d49f7adb
+
+  mongo:
+    container_name: mongo
+    image: mongo:6.0
+    mem_reservation: 1024M
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:
+    driver_opts:
+      size: 1G

--- a/nginx-flask-mongo/flask/.dockerignore
+++ b/nginx-flask-mongo/flask/.dockerignore
@@ -1,0 +1,6 @@
+Kraftfile
+Dockerfile
+.unikraft
+initrd
+rootfs
+.dockerignore

--- a/nginx-flask-mongo/flask/Dockerfile
+++ b/nginx-flask-mongo/flask/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-bookworm AS builder
+
+WORKDIR /app
+
+COPY requirements.txt /app
+RUN pip3 install -r requirements.txt --no-cache-dir
+
+COPY . /app
+
+FROM python:3.12-alpine
+
+WORKDIR /app
+
+COPY --from=builder /usr/local/lib/python3.12/site-packages/ /usr/local/lib/python3.12/site-packages/
+COPY --from=builder /app /app

--- a/nginx-flask-mongo/flask/Kraftfile
+++ b/nginx-flask-mongo/flask/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "off"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
+  # cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: [ "python", "/app/server.py" ]

--- a/nginx-flask-mongo/flask/requirements.txt
+++ b/nginx-flask-mongo/flask/requirements.txt
@@ -1,0 +1,2 @@
+pymongo
+flask

--- a/nginx-flask-mongo/flask/server.py
+++ b/nginx-flask-mongo/flask/server.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import os
+
+from flask import Flask
+from pymongo import MongoClient
+
+app = Flask(__name__)
+
+client_host = os.environ.get("MONGO_SERVER_URL", "mongodb-nginx-flask-mongo-mongo.internal")
+print(f"Connecting to MongoDB at {client_host}")
+
+try:
+    client = MongoClient(host=client_host, 
+                       directConnection=True,
+                       serverSelectionTimeoutMS=2000, 
+                       appname="unikraft")
+except Exception as e:
+    print(f"Error creating MongoDB client: {e}")
+
+@app.route('/')
+def todo():
+    try:
+        client.admin.command('ismaster')
+        return "Hello from the MongoDB client!\n"
+    except Exception as e:
+        print(f"MongoDB connection error: {e}")
+        return "MongoDB server not available, but Flask is running!\n"
+
+
+if __name__ == "__main__":
+    app.run(host='0.0.0.0', port=int(os.environ.get("FLASK_SERVER_PORT", 9090)), debug=False)

--- a/nginx-flask-mongo/nginx/Dockerfile
+++ b/nginx-flask-mongo/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.29.0-alpine
+
+COPY ./nginx.conf /etc/nginx/nginx.conf

--- a/nginx-flask-mongo/nginx/Kraftfile
+++ b/nginx-flask-mongo/nginx/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: [ "nginx" ]

--- a/nginx-flask-mongo/nginx/nginx.conf
+++ b/nginx-flask-mongo/nginx/nginx.conf
@@ -1,0 +1,33 @@
+worker_processes  1;
+daemon            off;
+master_process    off;
+user root root;
+
+events {
+  worker_connections  64;
+}
+
+http {
+  default_type application/octet-stream;
+
+  open_file_cache           max=10000 inactive=30s;
+  open_file_cache_min_uses  2;
+  open_file_cache_errors    on;
+
+  error_log stderr error;
+  access_log off;
+
+  keepalive_timeout     10s;
+  keepalive_requests    10000;
+  send_timeout          10s;
+
+  server {
+    listen              80;
+
+    server_name         127.0.0.1;
+
+    location / {
+      proxy_pass http://backend.internal:9091;
+    }
+  }
+}


### PR DESCRIPTION
Currently not working as the latest version of `PyMongo` used in the python backend uses subprocesses.

Either replace the library with something else, or switch to `base-compat:latest`

Inspired from: https://github.com/docker/awesome-compose/tree/master/nginx-flask-mongo