### PR TITLE
fix: update rust container version to fix build time failure

### DIFF
--- a/http-rust1.75-rocket0.5/Dockerfile
+++ b/http-rust1.75-rocket0.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75.0-bookworm AS build
+FROM --platform=x86_64 rust:1.81.0-bookworm AS build
 
 RUN cargo new --bin app
 WORKDIR /app
@@ -14,4 +14,4 @@ COPY --from=build /app/target/release/hello /server
 COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
 COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/
 COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
-COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/
+COPY --from=build /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /lib/x86_64-linux-gnu/


### PR DESCRIPTION
update rust container version for `http-rust1.75-rocket0.5` example to fix build time failure.