### PR TITLE
fix: Copy the proper dynamic linker through the symlink target

### DIFF
--- a/http-rust1.75-rocket0.5/Dockerfile
+++ b/http-rust1.75-rocket0.5/Dockerfile
@@ -14,4 +14,4 @@ COPY --from=build /app/target/release/hello /server
 COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/
 COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/
 COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
-COPY --from=build /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /lib/x86_64-linux-gnu/
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
The interpreter/linker's path defined by the tested binary is `/lib64/ld-linux-x86-64.so.2`. In the container this is actually a symlink to `/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2`, but the target would have been the one copied anyway.

Regardless, the interpreter we pick in Unikraft's elfloader is the one we extract from the ELF headers which has the former path.