### PR TITLE
 feat(examples): Add Python-FastAPI example

### DIFF
--- a/.github/workflows/example-http-python3.12-FastAPI-0.121.3-stable.yaml
+++ b/.github/workflows/example-http-python3.12-FastAPI-0.121.3-stable.yaml
@@ -1,0 +1,73 @@
+name: examples/http-python3.12-FastAPI-0.121.3 (stable)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-python3.12-FastAPI-0.121.3-stable.yaml'
+    - 'http-python3.12-FastAPI-0.121.3/**'
+    - '!http-python3.12-FastAPI-0.121.3/README.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-python3.12-FastAPI-0.121.3-stable.yaml'
+    - 'http-python3.12-FastAPI-0.121.3/**'
+    - '!http-python3.12-FastAPI-0.121.3/README.md'
+  schedule:
+  - cron: '0 2 * * 1-5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STABLE }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: info
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Deploy
+      uses: unikraft/kraftkit@stable
+      with:
+        run: |
+          set -xe;
+          cd http-python3.12-FastAPI-0.121.3;
+          kraft cloud deploy \
+            --no-start \
+            --memory 512 \
+            --name fastapi-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official/base-compat:latest \
+            --subdomain fastapi-${GITHUB_RUN_ID} \
+            -p 443:8080 \
+            .;
+
+    - name: Start & Test
+      uses: unikraft/kraftkit@stable
+      with:
+        run: |
+          set -xe;
+          kraft cloud vm start -w 5s fastapi-${GITHUB_RUN_ID};
+          sleep 5;
+          curl -Lv --fail-with-body --max-time 10 \
+            https://fastapi-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STABLE }}.unikraft.app/ \
+            | grep -q '{"Hello":"World"}'
+
+    - name: Cleanup
+      uses: unikraft/kraftkit@stable
+      if: always()
+      with:
+        run: |
+          set -xe;
+          kraft cloud vm stop fastapi-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs fastapi-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm fastapi-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/fastapi-${GITHUB_RUN_ID} || true;

--- a/.github/workflows/example-http-python3.12-FastAPI-0.121.3-staging.yaml
+++ b/.github/workflows/example-http-python3.12-FastAPI-0.121.3-staging.yaml
@@ -1,0 +1,73 @@
+name: examples/http-python3.12-FastAPI-0.121.3 (staging)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-python3.12-FastAPI-0.121.3-staging.yaml'
+    - 'http-python3.12-FastAPI-0.121.3/**'
+    - '!http-python3.12-FastAPI-0.121.3/README.md'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-python3.12-FastAPI-0.121.3-staging.yaml'
+    - 'http-python3.12-FastAPI-0.121.3/**'
+    - '!http-python3.12-FastAPI-0.121.3/README.md'
+  schedule:
+  - cron: '0 15 * * 1-5'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STAGING }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Deploy
+      uses: unikraft/kraftkit@staging
+      with:
+        run: |
+          set -xe;
+          cd http-python3.12-FastAPI-0.121.3;
+          kraft cloud deploy \
+            --no-start \
+            --memory 512 \
+            --name fastapi-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-staging/base-compat:latest \
+            --subdomain fastapi-${GITHUB_RUN_ID} \
+            -p 443:8080 \
+            .;
+
+    - name: Start & Test
+      uses: unikraft/kraftkit@staging
+      with:
+        run: |
+          set -xe;
+          kraft cloud vm start -w 5s fastapi-${GITHUB_RUN_ID};
+          sleep 5;
+          curl -Lv --fail-with-body --max-time 10 \
+            https://fastapi-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STAGING }}.unikraft.app/ \
+            | grep -q '{"Hello":"World"}'
+
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+          kraft cloud vm stop fastapi-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs fastapi-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm fastapi-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/fastapi-${GITHUB_RUN_ID} || true;

--- a/http-python3.12-FastAPI-0.121.3/.dockerignore
+++ b/http-python3.12-FastAPI-0.121.3/.dockerignore
@@ -1,0 +1,2 @@
+/.unikraft/
+/.testenv/

--- a/http-python3.12-FastAPI-0.121.3/.gitignore
+++ b/http-python3.12-FastAPI-0.121.3/.gitignore
@@ -1,0 +1,2 @@
+/.unikraft/
+/testenv

--- a/http-python3.12-FastAPI-0.121.3/Dockerfile
+++ b/http-python3.12-FastAPI-0.121.3/Dockerfile
@@ -1,0 +1,34 @@
+# Add the image of Python 3.12.
+FROM python:3.12-bookworm AS build
+
+# Check for newly installed shared libraries with error output if necessary.
+RUN set -xe; \
+    /usr/sbin/ldconfig /usr/local/lib
+
+WORKDIR /app
+
+# Install the required packages for the taskCOPY requirements.txt /app.
+COPY ./requirements.txt /app
+RUN pip3 install -r requirements.txt --no-cache-dir
+
+# Add an empty image.
+FROM scratch
+
+# Copy the dependencies and libraries from build image inside scratch.
+COPY --from=build /usr/local/lib /usr/local/lib
+COPY --from=build /usr/local/bin/python3 /usr/bin/python3
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/libz.so.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libssl.so.3 /usr/lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=build /usr/lib/x86_64-linux-gnu/librt.so.1 /usr/lib/x86_64-linux-gnu/librt.so.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libcrypto.so.3 /usr/lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libdl.so.2 /usr/lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /usr/lib/x86_64-linux-gnu/libpthread.so.0 /usr/lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# Copy the server from local machine to scratch image.
+COPY ./server.py /src/server.py

--- a/http-python3.12-FastAPI-0.121.3/Kraftfile
+++ b/http-python3.12-FastAPI-0.121.3/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/http-python3.12-FastAPI-0.121.3/README.md
+++ b/http-python3.12-FastAPI-0.121.3/README.md
@@ -1,0 +1,168 @@
+# FastAPI
+
+This guide explains how to create and deploy a Python FastAPI web app.
+To run this example, follow these steps:
+
+1. Install the [`kraft` CLI tool](https://unikraft.org/docs/cli/install) and a container runtime engine, for example [Docker](https://docs.docker.com/engine/install/).
+
+1. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/http-python3.12-FastAPI-0.121.3/` directory:
+
+```bash
+git clone https://github.com/unikraft-cloud/examples
+cd examples/http-python3.12-FastAPI-0.121.3/
+```
+
+Make sure to log into Unikraft Cloud by setting your token and a [metro](https://unikraft.com/docs/platform/metros) close to you.
+This guide uses `fra` (Frankfurt, 🇩🇪):
+
+```bash
+export UKC_TOKEN=token
+# Set metro to Frankfurt, DE
+export UKC_METRO=fra
+```
+
+When done, invoke the following command to deploy this app on Unikraft Cloud:
+
+```bash
+kraft cloud deploy -M 512 -p 443:8080 .
+```
+
+The output shows the instance address and other details:
+
+```text
+ [●] Deployed successfully!
+ │
+ ├────── name: http-python312-fastapi-01213-0n84f                                                                                 
+ ├────── uuid: 5d7fc331-3c23-4953-b025-d152a872ea29                                                                               
+ ├───── metro: fra                                                                                                                
+ ├───── state: running                                                                                                   
+ ├──── domain: https://dry-water-0oexx89g.fra.unikraft.app                                                                        
+ ├───── image: paun-cristian/http-python312-fastapi-01213@sha256:fb2a00dcf1cfc3ac821cbda05f82f38d66e63121344b9bc60c6a6e2f11917b98 
+ ├─ boot time: 170.42 ms                                                                                                          
+ ├──── memory: 512 MiB                                                                                                            
+ ├─── service: dry-water-0oexx89g                                                                                                 
+ ├ private ip: 10.0.1.69                                                                                                          
+ └────── args: /usr/bin/python3 -m uvicorn src.server:app --host 0.0.0.0 --port 8080     
+```
+
+In this case, the instance name is `http-python312-fastapi-01213-0n84f` and the address is `ttps://dry-water-0oexx89g.fra.unikraft.app`.
+They're different for each run.
+
+Use `curl` to query the Unikraft Cloud instance of the Django web app server:
+
+```bash
+curl ttps://dry-water-0oexx89g.fra.unikraft.app
+```
+
+```text
+{"Hello":"World"}
+```
+You can list information about the instance by running:
+
+```bash
+kraft cloud instance list
+```
+```ansi
+NAME                                FQDN                                 STATE    STATUS   IMAGE                                                MEMORY   VCPUS  ARGS                                                 BOOT TIME
+http-python312-fastapi-01213-0n84f  dry-water-0oexx89g.fra.unikraft.app  standby  standby  paun-cristian/http-python312-fastapi-01213@sha25...  512 MiB  1      /usr/bin/python3 -m uvicorn src.server:app --hos...  169.45 ms
+```
+
+When done, you can remove the instance:
+
+```bash
+kraft cloud instance remove http-python312-fastapi-01213-0n84f
+```
+
+## Customize your app
+
+To customize the app, update the files in the repository, listed below:
+
+* `server.py`: the entry point for the app
+* `Kraftfile`: the Unikraft Cloud specification
+* `Dockerfile`: the Docker-specified app filesystem
+
+Lines in the `Kraftfile` have the following roles:
+
+* `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
+
+* `runtime: base-compat:latest`: The Unikraft runtime kernel to use is the latest that provides a minimal Linux-compatible environment.
+
+* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+
+* `cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]`: Use this as the starting command of the instance.
+
+Lines in the `Dockerfile` have the following roles:
+
+* `FROM scratch`: Build the filesystem from the [`scratch` container image](https://hub.docker.com/_/scratch/), to [create a base image](https://docs.docker.com/build/building/base-images/).
+
+The following options are available for customizing the app:
+
+* If you only update the implementation in the `server.py` source file, you don't need to make any other changes.
+
+* If you create any new source files, copy them into the app filesystem by using the `COPY` command in the `Dockerfile`.
+
+* More extensive changes may require extending the `Dockerfile` ([see `Dockerfile` syntax reference](https://docs.docker.com/engine/reference/builder/)).
+  This includes the use of Python frameworks and the use of `pip`, as shown in the next section.
+
+## Using `pip`
+
+[`pip`](https://pip.pypa.io/en/stable/) is a package manager for Python.
+It's used to install dependencies for Python apps.
+`pip` uses the `requirements.txt` file to list required dependencies (with versions).
+
+The [`http-python3.12-FastAPI-0.121.3`](https://github.com/paun-cristian/examples/tree/main/http-python3.12-FastAPI-0.121.3) guide details the use of `pip` to deploy an app using the [`FastAPI`](https://fastapi.tiangolo.com/) framework on Unikraft Cloud.
+
+Run the command below to deploy the app on Unikraft Cloud:
+
+```bash
+kraft cloud deploy -M 512 -p 443:8080 .
+```
+
+Differences from the FastAPI app are also the steps required to create an `pip`-based app:
+
+1. Add the `requirements.txt` file used by `pip`.
+
+2. Add framework-specific source files.
+   In this case, this means the `server.py` file.
+
+3. Update the `Dockerfile` to:
+
+   3.1. `COPY` the local files.
+
+   3.2. `RUN` the `pip3 install` command to install dependencies.
+
+   3.3. `COPY` of the resulting and required files (`/usr/local/lib/python3.12` and `server.py`) in the app filesystem, using the [`scratch` container](https://hub.docker.com/_/scratch/).
+
+The following lists the files:
+
+The `requirements.txt` file lists the `fastapi` and `uvicorn` dependencies.
+
+The `Kraftfile` is the same one used for `http-python3.12`, except changed lines that have the following roles:
+* `cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]`: Use `/usr/bin/python3 -m uvicorn src.server:app --host 0.0.0.0 --port 8080` as the starting command of the instance.
+
+For `Dockerfile` newly added lines have the following roles:
+
+* `FROM python:3.12-bookworm AS build`: Use the base image of the `python:3.12-bookworm` container.
+  This provides the `pip3` binary and other Python-related components.
+  Name the current image `build`.
+
+* `WORKDIR /app`: Use `/app` as working directory.
+  All other commands in the `Dockerfile` run inside this directory.
+
+* `COPY requirements.txt /app`: Copy the package configuration file to the Docker filesystem.
+
+* `RUN pip3 install ...`: Install `pip` components listed in `requirements.txt`.
+
+* `COPY --from=build ...`: Copy generated Python files in the new `build` image in the `scratch`-based image.
+
+Similar actions apply to other `pip3`-based apps.
+
+## Learn more
+
+Use the `--help` option for detailed information on using Unikraft Cloud:
+
+```bash
+kraft cloud --help
+```
+
+Or visit the [CLI Reference](https://unikraft.com/docs/cli/overview).

--- a/http-python3.12-FastAPI-0.121.3/requirements.txt
+++ b/http-python3.12-FastAPI-0.121.3/requirements.txt
@@ -1,0 +1,2 @@
+fastapi[standard]
+uvicorn

--- a/http-python3.12-FastAPI-0.121.3/server.py
+++ b/http-python3.12-FastAPI-0.121.3/server.py
@@ -1,0 +1,14 @@
+from typing import Union
+import uvicorn
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+def read_root():
+    return {"Hello": "World"}
+
+
+if __name__ == '__main__':
+    uvicorn.run(app, port=8080, host='0.0.0.0')


### PR DESCRIPTION
Introduce Python3.12-FastAPI example to deploy on Kraftcloud. It uses the `base-compat:latest` image.
Add:

-     Kraftfile: build / run rules
-     Dockerfile: placeholder to extract the filesystem
-     server.py: simple Python FastAPI HTTP server
-     README.md: document how to use
