### PR TITLE
fix: Add correct memory value in READMEs

### DIFF
--- a/.github/workflows/example-node21-nextjs-stable.yaml
+++ b/.github/workflows/example-node21-nextjs-stable.yaml
@@ -51,7 +51,7 @@ jobs:
 
           kraft cloud deploy \
             --no-start \
-            --memory 756 \
+            --memory 768 \
             --name node21-nextjs-stable-${GITHUB_RUN_ID} \
             --runtime index.unikraft.io/official-testing/base-compat:latest \
             --subdomain node21-nextjs-stable-${GITHUB_RUN_ID} \

--- a/.github/workflows/example-node21-nextjs-staging.yaml
+++ b/.github/workflows/example-node21-nextjs-staging.yaml
@@ -51,7 +51,7 @@ jobs:
 
           kraft cloud deploy \
             --no-start \
-            --memory 756 \
+            --memory 768 \
             --name node21-nextjs-staging-${GITHUB_RUN_ID} \
             --runtime index.unikraft.io/official-staging/base-compat:latest \
             --subdomain node21-nextjs-staging-${GITHUB_RUN_ID} \

--- a/.github/workflows/example-node21-remix-stable.yaml
+++ b/.github/workflows/example-node21-remix-stable.yaml
@@ -51,7 +51,7 @@ jobs:
 
           kraft cloud deploy \
             --no-start \
-            --memory 756 \
+            --memory 768 \
             --name node21-remix-stable-${GITHUB_RUN_ID} \
             --runtime index.unikraft.io/official-testing/base-compat:latest \
             --subdomain node21-remix-stable-${GITHUB_RUN_ID} \

--- a/.github/workflows/example-node21-remix-staging.yaml
+++ b/.github/workflows/example-node21-remix-staging.yaml
@@ -51,7 +51,7 @@ jobs:
 
           kraft cloud deploy \
             --no-start \
-            --memory 756 \
+            --memory 768 \
             --name node21-remix-staging-${GITHUB_RUN_ID} \
             --runtime index.unikraft.io/official-staging/base-compat:latest \
             --subdomain node21-remix-staging-${GITHUB_RUN_ID} \

--- a/duckdb-go/README.md
+++ b/duckdb-go/README.md
@@ -25,7 +25,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -p 443:8080 -M 256Mi .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://autumn-gorilla-hg4h6sup.fra.unikraft.app
  ├───────── image: duckdb-go@sha256:6999293f8694ac00beb6a1d639fab8f96f78c2e6ecb8ccb2311539908895a699
  ├───── boot time: 32.12 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: autumn-gorilla-hg4h6sup
  ├── private fqdn: duckdb-go-qfd8x.internal
  ├──── private ip: 172.16.6.2
@@ -65,7 +65,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME             FQDN                                      STATE    STATUS        IMAGE         MEMORY   VCPUS  ARGS     BOOT TIME
-duckdb-go-qfd8x  autumn-gorilla-hg4h6sup.fra.unikraft.app  running  1 minute ago  duckdb-go...  128 MiB  1      /server  32118us
+duckdb-go-qfd8x  autumn-gorilla-hg4h6sup.fra.unikraft.app  running  1 minute ago  duckdb-go...  256 MiB  1      /server  32118us
 ```
 
 When done, you can remove the instance:

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -25,7 +25,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 1024 .
+kraft cloud deploy -p 443:3000 -M 2048 .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://icy-sea-i6m5fwyk.fra.unikraft.app
  ├───────── image: grafana@sha256:484d6f98cdc321443188b8f2900035182dffdb45069f3cd087dcb6851ddff3bc
  ├───── boot time: 502.65 ms
- ├──────── memory: 1024 MiB
+ ├──────── memory: 2048 MiB
  ├─────── service: dawn-water-4jlnvgpy
  ├── private fqdn: grafana-mgby4.internal
  ├──── private ip: 172.16.6.6
@@ -59,7 +59,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME           FQDN                               STATE    STATUS          IMAGE                        MEMORY    VCPUS  ARGS                                      BOOT TIME
-grafana-sikrv  icy-sea-i6m5fwyk.fra.unikraft.app  running  11 minutes ago  grafana@sha256:484d6f98c...  1024 MiB  1      /usr/share/grafana/bin/grafana server...  502651us
+grafana-sikrv  icy-sea-i6m5fwyk.fra.unikraft.app  running  11 minutes ago  grafana@sha256:484d6f98c...  2048 MiB  1      /usr/share/grafana/bin/grafana server...  502651us
 ```
 
 When done, you can remove the instance:

--- a/http-c-debug/README.md
+++ b/http-c-debug/README.md
@@ -24,13 +24,13 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080/http+tls -p 2222:2222/tls -e PUBKEY="...." .
+kraft cloud deploy -M 256Mi -p 443:8080/http+tls -p 2222:2222/tls -e PUBKEY="...." .
 ```
 
 For extensive debug information with `strace`, add the `USE_STRACE=1` environment variable to the deploy command:
 
 ```bash
-kraft cloud deploy -p 443:8080 -p 2222:2222 -e PUBKEY="...." -e USE_STRACE=1 .
+kraft cloud deploy -M 256Mi -p 443:8080 -p 2222:2222 -e PUBKEY="...." -e USE_STRACE=1 .
 ```
 
 The output shows the instance address and other details:
@@ -45,7 +45,7 @@ The output shows the instance address and other details:
  ├──── domain: https://patient-snow-zdzhdy8r.fra.unikraft.app
  ├───── image: http-c-debug@sha256:b24b95e236c8eff69615dd4f5d257beed5ee4047fd98d1b6fb200f89c63fa54c 
  ├─ boot time: 66.56 ms
- ├──── memory: 128 MiB
+ ├──── memory: 256 MiB
  ├─── service: patient-snow-zdzhdy8r
  ├ private ip: 10.0.0.109
  └────── args: /usr/bin/wrapper.sh
@@ -86,7 +86,7 @@ kraft cloud instance list
 
 ```ansi
 NAME                FQDN                                    STATE    STATUS       IMAGE                      MEMORY   VCPUS  ARGS                 BOOT TIME
-http-c-debug-5pvem  patient-snow-zdzhdy8r.fra.unikraft.app  running  since 4mins  http-c-debug@sha256:b2...  128 MiB  1      /usr/bin/wrapper.sh  66.56 ms
+http-c-debug-5pvem  patient-snow-zdzhdy8r.fra.unikraft.app  running  since 4mins  http-c-debug@sha256:b2...  256 MiB  1      /usr/bin/wrapper.sh  66.56 ms
 ```
 
 When done, you can remove the instance:

--- a/http-c/README.md
+++ b/http-c/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├──── domain: https://still-resonance-bja3lste.fra.unikraft.app
  ├───── image: http-c@sha256:375677bf052f14c18ca79c86d2f47a68f3ea5f8636bcd8830753a254f0e06c1b 
  ├─ boot time: 13.29 ms
- ├──── memory: 128 MiB
+ ├──── memory: 256 MiB
  ├─── service: still-resonance-bja3lste
  ├ private ip: 10.0.0.49
  └────── args: /http_server
@@ -66,7 +66,7 @@ kraft cloud instance list
 
 ```ansi
 NAME          FQDN                                       STATE    STATUS   IMAGE                                     MEMORY   VCPUS  ARGS          BOOT TIME
-http-c-is2s9  still-resonance-bja3lste.fra.unikraft.app  standby  standby  http-c@sha256:375677bf052f14c18ca79c8...  128 MiB  1      /http_server  12.91 ms
+http-c-is2s9  still-resonance-bja3lste.fra.unikraft.app  standby  standby  http-c@sha256:375677bf052f14c18ca79c8...  256 MiB  1      /http_server  12.91 ms
 ```
 
 When done, you can remove the instance:

--- a/http-cpp-boost/README.md
+++ b/http-cpp-boost/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://red-snow-3bn7bzc8.fra.unikraft.app
  ├───────── image: http-cpp-boost@sha256:61cf86b89fed46351af53689e27189315e466576475f61c7240bf17644613489
  ├───── boot time: 15.00 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: red-snow-3bn7bzc8
  ├── private fqdn: http-cpp-boost-rae7s.internal
  ├──── private ip: 172.16.6.4
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                  FQDN                                STATE    STATUS        IMAGE                                                        MEMORY   VCPUS  ARGS          BOOT TIME
-http-cpp-boost-rae7s  red-snow-3bn7bzc8.fra.unikraft.app  running  1 minute ago  http-cpp-boost@sha256:61cf86b89fed46351af53689e27189315e...  128 MiB  1      /http_server  15000us
+http-cpp-boost-rae7s  red-snow-3bn7bzc8.fra.unikraft.app  running  1 minute ago  http-cpp-boost@sha256:61cf86b89fed46351af53689e27189315e...  256 MiB  1      /http_server  15000us
 ```
 
 When done, you can remove the instance:

--- a/http-cpp/README.md
+++ b/http-cpp/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://throbbing-wave-grxjih4t.fra.unikraft.app
  ├───────── image: http-cpp@sha256:a58873987104b52c13b79168a2e2f1a81876ba6efacd6dbc98e996afe5c09699
  ├───── boot time: 15.61 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: throbbing-wave-grxjih4t
  ├── private fqdn: http-cpp-jzbuo.internal
  ├──── private ip: 172.16.6.5
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME            FQDN                                      STATE    STATUS        IMAGE                                                           MEMORY   VCPUS  ARGS          BOOT TIME
-http-cpp-jzbuo  throbbing-wave-grxjih4t.fra.unikraft.app  running  1 minute ago  http-cpp@sha256:a58873987104b52c13b79168a2e2f1a81876ba6efac...  128 MiB  1      /http_server  15614us
+http-cpp-jzbuo  throbbing-wave-grxjih4t.fra.unikraft.app  running  1 minute ago  http-cpp@sha256:a58873987104b52c13b79168a2e2f1a81876ba6efac...  256 MiB  1      /http_server  15614us
 ```
 
 When done, you can remove the instance:

--- a/http-go1.21/README.md
+++ b/http-go1.21/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://red-dew-jtk6yxk1.fra.unikraft.app
  ├───────── image: http-go121@sha256:b16d61bb7898e764d8c11ab5a0b995e8c25a25b5ff89e161fc994ebf25a75680
  ├───── boot time: 11.05 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: red-dew-jtk6yxk1
  ├── private fqdn: http-go121-9a2wv.internal
  ├──── private ip: 172.16.3.3
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME              FQDN                               STATE    STATUS        IMAGE                                        MEMORY   VCPUS  ARGS     BOOT TIME
-http-go121-9a2wv  red-dew-jtk6yxk1.fra.unikraft.app  running  1 minute ago  alex/http-go121@sha256:b16d61bb7898e764d...  128 MiB  1      /server  9324us
+http-go121-9a2wv  red-dew-jtk6yxk1.fra.unikraft.app  running  1 minute ago  alex/http-go121@sha256:b16d61bb7898e764d...  256 MiB  1      /server  9324us
 ```
 
 When done, you can remove the instance:

--- a/http-java17/README.md
+++ b/http-java17/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 -M 512 .
+kraft cloud deploy -p 443:8080 -M 1024 .
 ```
 
 The output shows the instance address and other details:

--- a/http-lua5.1/README.md
+++ b/http-lua5.1/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://young-night-5fpf0jj8.fra.unikraft.app
  ├───────── image: http-lua51@sha256:278cb8b14f9faf9c2702dddd8bfb6124912d82c11b4a2c6590b6e32fc4049472
  ├───── boot time: 15.09 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: young-night-5fpf0jj8
  ├── private fqdn: http-lua51-ma2i9.internal
  ├──── private ip: 172.16.3.3
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME              FQDN                                   STATE    STATUS        IMAGE                                    MEMORY   VCPUS  ARGS                           BOOT TIME
-http-lua51-ma2i9  young-night-5fpf0jj8.fra.unikraft.app  running  1 minute ago  http-lua51@sha256:278cb8b14f9faf9c27...  128 MiB  1      /usr/bin/lua /http_server.lua  15094us
+http-lua51-ma2i9  young-night-5fpf0jj8.fra.unikraft.app  running  1 minute ago  http-lua51@sha256:278cb8b14f9faf9c27...  256 MiB  1      /usr/bin/lua /http_server.lua  15094us
 ```
 
 When done, you can remove the instance:

--- a/http-node21/README.md
+++ b/http-node21/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 -M 256 .
+kraft cloud deploy -p 443:8080 -M 512 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://ancient-haze-sd3wwi0x.fra.unikraft.app
  ├───────── image: http-node21@sha256:de174e3703c79a048f0af52344c373296b55f3ca2b96cd29e16c1f014cefd232
  ├───── boot time: 41.65 ms
- ├──────── memory: 256 MiB
+ ├──────── memory: 512 MiB
  ├─────── service: ancient-haze-sd3wwi0x
  ├── private fqdn: http-node21-ubl8g.internal
  ├──── private ip: 172.16.3.3
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME               FQDN                                    STATE    STATUS          IMAGE                                   MEMORY   VCPUS  ARGS                              BOOT TIME
-http-node21-ubl8g  ancient-haze-sd3wwi0x.fra.unikraft.app  running  50 seconds ago  http-node21@sha256:de174e3703c79a04...  256 MiB  1      /usr/bin/node /usr/src/server.js  31654us
+http-node21-ubl8g  ancient-haze-sd3wwi0x.fra.unikraft.app  running  50 seconds ago  http-node21@sha256:de174e3703c79a04...  512 MiB  1      /usr/bin/node /usr/src/server.js  31654us
 ```
 
 When done, you can remove the instance:
@@ -125,7 +125,7 @@ cd examples/node21-expressjs/
 Run the command below to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 256 .
+kraft cloud deploy -p 443:3000 -M 512 .
 ```
 
 Differences from the `http-node21` app are also the steps required to create an `npm`-based app:

--- a/http-php8.2/README.md
+++ b/http-php8.2/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 512 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://aged-fire-rh0oi0tj.fra.unikraft.app
  ├───────── image: http-php82@sha256:dccaac053982673765b8f00497a9736c31458ab23ad59a550b09aa8dedfabb34
  ├───── boot time: 32.80 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 512 MiB
  ├─────── service: aged-fire-rh0oi0tj
  ├── private fqdn: http-php82-g00si.internal
  ├──── private ip: 172.16.3.3
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME              FQDN                                 STATE    STATUS          IMAGE                                   MEMORY   VCPUS  ARGS                                    BOOT TIME
-http-php82-g00si  aged-fire-rh0oi0tj.fra.unikraft.app  running  50 seconds ago  http-php82@sha256:dccaac05398267376...  256 MiB  1      /usr/local/bin/php /usr/src/server.php  32801us
+http-php82-g00si  aged-fire-rh0oi0tj.fra.unikraft.app  running  50 seconds ago  http-php82@sha256:dccaac05398267376...  512 MiB  1      /usr/local/bin/php /usr/src/server.php  32801us
 ```
 
 When done, you can remove the instance:

--- a/http-python3.12-django5.0/README.md
+++ b/http-python3.12-django5.0/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:80 -M 512 .
+kraft cloud deploy -p 443:80 -M 1024 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://dawn-sound-n5wrkxi2.fra.unikraft.app
  ├───────── image: http-python312-django50@sha256:221666d414299aff54dbf10020b3d540270ee0c5907c1c6a728ca254ce8b0e50
  ├───── boot time: 80.32 ms
- ├──────── memory: 512 MiB
+ ├──────── memory: 1024 MiB
  ├─────── service: dawn-sound-n5wrkxi2
  ├── private fqdn: http-python312-django50-vt56c.internal
  ├──── private ip: 172.16.6.5
@@ -85,8 +85,8 @@ You can list information about the instance by running:
 kraft cloud instance list
 ```
 ```ansi
-NAME                           FQDN                                  STATE    STATUS        IMAGE                                        MEMORY   VCPUS  ARGS                           BOOT TIME
-http-python312-django50-vt56c  dawn-sound-n5wrkxi2.fra.unikraft.app  running  1 minute ago  http-python312-django50@sha256:221666d41...  512 MiB  1      /usr/bin/python3 /app/main.py  80321us
+NAME                           FQDN                                  STATE    STATUS        IMAGE                                        MEMORY    VCPUS  ARGS                           BOOT TIME
+http-python312-django50-vt56c  dawn-sound-n5wrkxi2.fra.unikraft.app  running  1 minute ago  http-python312-django50@sha256:221666d41...  1024 MiB  1      /usr/bin/python3 /app/main.py  80321us
 ```
 
 When done, you can remove the instance:
@@ -137,7 +137,7 @@ The [`http-python3.12-flask3.0`](https://github.com/unikraft-cloud/examples/tree
 Run the command below to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:80 -M 512 .
+kraft cloud deploy -p 443:80 -M 1024 .
 ```
 
 Differences from the Django app are also the steps required to create an `pip`-based app:

--- a/http-rust1.73/README.md
+++ b/http-rust1.73/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├──── domain: https://hidden-sky-c1tp5r6e.fra.unikraft.app
  ├───── image: http-rust173@sha256:451277edb27c1201929d2da12898d910cca2f0a2ca71b8f8fa7da22c23a10bba 
  ├─ boot time: 17.49 ms
- ├──── memory: 128 MiB
+ ├──── memory: 256 MiB
  ├─── service: hidden-sky-c1tp5r6e
  ├ private ip: 10.0.0.109
  └────── args: /server
@@ -66,7 +66,7 @@ kraft cloud instance list
 
 ```ansi
 NAME                FQDN                                  STATE    STATUS   IMAGE                                    MEMORY   VCPUS  ARGS     BOOT TIME
-http-rust173-8gsmk  hidden-sky-c1tp5r6e.fra.unikraft.app  standby  standby  http-rust173@sha256:451277edb27c1201...  128 MiB  1      /server  17.49 ms
+http-rust173-8gsmk  hidden-sky-c1tp5r6e.fra.unikraft.app  standby  standby  http-rust173@sha256:451277edb27c1201...  256 MiB  1      /server  17.49 ms
 ```
 
 When done, you can remove the instance:

--- a/http-rust1.75-tokio/README.md
+++ b/http-rust1.75-tokio/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://empty-dawn-3coedrce.fra.unikraft.app
  ├───────── image: http-rust175-tokio@sha256:0ce75912711aa2329232a2ca6c3ccb7a244b6d546fafc081f815c2fde8224856
  ├───── boot time: 21.41 ms
- ├──────── memory: 128 Mi
+ ├──────── memory: 256 Mi
  ├─────── service: empty-dawn-3coedrce
  ├── private fqdn: http-rust175-tokio-6gxsp.internal
  ├──── private ip: 172.16.6.3
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                      FQDN                                  STATE    STATUS        IMAGE                                  MEMORY   VCPUS  ARGS     BOOT TIME
-http-rust175-tokio-6gxsp  empty-dawn-3coedrce.fra.unikraft.app  running  1 minute ago  http-rust175-tokio@sha256:0ce75912...  128 MiB  1      /server  21412us
+http-rust175-tokio-6gxsp  empty-dawn-3coedrce.fra.unikraft.app  running  1 minute ago  http-rust175-tokio@sha256:0ce75912...  256 MiB  1      /server  21412us
 ```
 
 When done, you can remove the instance:

--- a/http-rust1.81-rocket0.5/README.md
+++ b/http-rust1.81-rocket0.5/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://empty-bobo-n3htmpye.fra.unikraft.app
  ├───────── image: http-rust175-rocket05@sha256:23a7a6e155758e6e8f75e9570f0aec5fb744f08c1bad2454d7386367c5ea45d6
  ├───── boot time: 17.41 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: empty-bobo-n3htmpye
  ├── private fqdn: http-rust175-rocket05-tuwq3.internal
  ├──── private ip: 172.16.6.6
@@ -64,7 +64,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                         FQDN                                  STATE    STATUS        IMAGE                                   MEMORY   VCPUS  ARGS     BOOT TIME
-http-rust175-rocket05-tuwq3  empty-bobo-n3htmpye.fra.unikraft.app  running  1 minute ago  http-rust175-rocket05@sha256:23a7a6...  128 MiB  1      /server  17412us
+http-rust175-rocket05-tuwq3  empty-bobo-n3htmpye.fra.unikraft.app  running  1 minute ago  http-rust175-rocket05@sha256:23a7a6...  256 MiB  1      /server  17412us
 ```
 
 When done, you can remove the instance:

--- a/http-rust1.87-actix-web4/README.md
+++ b/http-rust1.87-actix-web4/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://autumn-silence-wupu2nus.fra.unikraft.app
  ├───────── image: http-rust187-actix-web4@sha256:11723705230f0f4545d2be7e4867dc67b396870769e91f05e2fa6d9da94f9b59
  ├───── boot time: 11.67 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: autumn-silence-wupu2nus
  ├── private fqdn: http-rust187-actix-web4-3pj27.internal
  ├──── private ip: 172.16.3.3
@@ -66,7 +66,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                           FQDN                                      STATE    STATUS          IMAGE                                                      MEMORY   VCPUS  ARGS     BOOT TIME
-http-rust187-actix-web4-3pj27  autumn-silence-wupu2nus.fra.unikraft.app  running  10 minutes ago  http-rust187-actix-web4@sha256:11723705230f0f4545d2be7...  128 MiB  1      /server  11672us
+http-rust187-actix-web4-3pj27  autumn-silence-wupu2nus.fra.unikraft.app  running  10 minutes ago  http-rust187-actix-web4@sha256:11723705230f0f4545d2be7...  256 MiB  1      /server  11672us
 ```
 
 When done, you can remove the instance:

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -26,7 +26,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 .
+kraft cloud deploy -M 256 -p 443:8080 .
 ```
 
 The output shows the instance address and other details:
@@ -40,7 +40,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://nameless-fog-0tvh1uov.fra.unikraft.app
  ├───────── image: nginx@sha256:f51ecc121c9ca34abb88a2bc6a69765501304f7893f7e85af15fbec3dc86e2bd
  ├───── boot time: 11.13ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: nameless-fog-0tvh1uov
  ├── private fqdn: nginx-67zbu.internal
  ├──── private ip: 172.16.3.3
@@ -70,7 +70,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME         FQDN                                    STATE    STATUS         IMAGE                               MEMORY   VCPUS  ARGS                                     BOOT TIME
-nginx-67zbu  nameless-fog-0tvh1uov.fra.unikraft.app  running  5 minutes ago  nginx@sha256:f51ecc121c9ca34abb...  128 MiB  1      /usr/bin/nginx -c /etc/nginx/nginx.conf  11129us
+nginx-67zbu  nameless-fog-0tvh1uov.fra.unikraft.app  running  5 minutes ago  nginx@sha256:f51ecc121c9ca34abb...  256 MiB  1      /usr/bin/nginx -c /etc/nginx/nginx.conf  11129us
 ```
 
 When done, you can remove the instance:

--- a/node-playwright-firefox/README.md
+++ b/node-playwright-firefox/README.md
@@ -6,7 +6,7 @@ To run Playwright (Firefox) with Node.js on Unikraft Cloud, first [install the `
 Then clone this repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy -M 2048 -p 443:8080 .
+kraft cloud deploy -M 4096 -p 443:8080 .
 ```
 
 The command will deploy the files in the current directory.

--- a/node21-expressjs/README.md
+++ b/node21-expressjs/README.md
@@ -6,7 +6,7 @@ To run Express on Unikraft Cloud, first [install the `kraft` CLI tool](https://u
 Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```console
-kraft cloud deploy --metro fra -p 443:3000 -M 256 .
+kraft cloud deploy --metro fra -p 443:3000 -M 512 .
 ```
 
 The command will deploy the files under `app/`.

--- a/node21-nextjs/README.md
+++ b/node21-nextjs/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 256 .
+kraft cloud deploy -p 443:3000 -M 768 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://small-frog-ri8c1vtw.fra.unikraft.app
  ├───────── image: node21-nextjs@sha256:ea5b2f145eea9762431ebdea933dd1dfb8427fe23306d2bd7966dd502d6c88f6
  ├───── boot time: 83.60 ms
- ├──────── memory: 256 MiB
+ ├──────── memory: 768 MiB
  ├─────── service: small-frog-ri8c1vtw
  ├── private fqdn: node21-nextjs-bfrq0.internal
  ├──── private ip: 172.16.28.2
@@ -66,7 +66,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                 FQDN                                  STATE    STATUS        IMAGE                    MEMORY   VCPUS  ARGS                              BOOT TIME
-node21-nextjs-bfrq0  small-frog-ri8c1vtw.fra.unikraft.app  running  1 minute ago  node21-nextjs@sha256...  256 MiB  1      /usr/bin/node /usr/src/server.js  83600us
+node21-nextjs-bfrq0  small-frog-ri8c1vtw.fra.unikraft.app  running  1 minute ago  node21-nextjs@sha256...  768 MiB  1      /usr/bin/node /usr/src/server.js  83600us
 ```
 
 When done, you can remove the instance:

--- a/node21-remix/README.md
+++ b/node21-remix/README.md
@@ -25,7 +25,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 512 .
+kraft cloud deploy -p 443:3000 -M 768 .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://long-star-1tms9h1z.fra.unikraft.app
  ├───────── image: node21-remix@sha256:300eefce3de136ad9c782f010b69da01100ae5f0ca17f038f92321d735d6675f
  ├───── boot time: 153.47 ms
- ├──────── memory: 512 MiB
+ ├──────── memory: 768 MiB
  ├─────── service: long-star-1tms9h1z
  ├── private fqdn: node21-remix-jvj6b.internal
  ├──── private ip: 172.16.6.8
@@ -57,7 +57,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                FQDN                                 STATE    STATUS         IMAGE          MEMORY   VCPUS  ARGS                              BOOT TIME
-node21-remix-jvj6b  long-star-1tms9h1z.fra.unikraft.app  running  1 minutes ago  node21-rem...  256 MiB  1      /usr/bin/node /usr/src/server...  67.65 ms
+node21-remix-jvj6b  long-star-1tms9h1z.fra.unikraft.app  running  1 minutes ago  node21-rem...  768 MiB  1      /usr/bin/node /usr/src/server...  67.65 ms
 ```
 
 When done, you can remove the instance:

--- a/node21-solid-start/README.md
+++ b/node21-solid-start/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy the app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 256 .
+kraft cloud deploy -p 443:3000 -M 512 .
 ```
 
 The output shows the instance address and other details:
@@ -38,7 +38,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://long-star-1tms9h1z.fra.unikraft.app
  ├───────── image: node21-solid-start@sha256:eb2e79b2fc5c28bb43923a1fc4931db94ebc3f939a6fbe00d06189c0ae2e02fd
  ├───── boot time: 67.65 ms
- ├──────── memory: 256 MiB
+ ├──────── memory: 512 MiB
  ├─────── service: long-star-1tms9h1z
  ├── private fqdn: node21-solid-start-lvoa2.internal
  ├──── private ip: 172.16.6.8
@@ -56,7 +56,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                      FQDN                                 STATE    STATUS         IMAGE          MEMORY   VCPUS  ARGS                              BOOT TIME
-node21-solid-start-lvoa2  long-star-1tms9h1z.fra.unikraft.app  running  1 minutes ago  node21-sol...  256 MiB  1      /usr/bin/node /usr/src/server...  67.65 ms
+node21-solid-start-lvoa2  long-star-1tms9h1z.fra.unikraft.app  running  1 minutes ago  node21-sol...  512 MiB  1      /usr/bin/node /usr/src/server...  67.65 ms
 ```
 
 When done, you can remove the instance:

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -27,7 +27,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -M 1024M .
+kraft cloud deploy -M 1536M .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├────────── uuid: 40e8b154-b3b6-4312-ae69-2cdb794b15e4
  ├───────── state: starting
  ├───────── image: opentelemetry-collector@sha256:64f73ea5fe208f54e5212f57979f24bebcf36276495462c52b380d15dd539ced
- ├──────── memory: 976 MiB
+ ├──────── memory: 1536 MiB
  ├── private fqdn: opentelemetry-collector-bvtnh.internal
  ├──── private ip: 172.16.3.3
  └────────── args: /usr/bin/otelcontribcol --config /etc/otel/config.yaml
@@ -59,8 +59,8 @@ You can list information about the instance by running:
 kraft cloud instance list
 ```
 ```ansi
-NAME                           FQDN  STATE    STATUS        IMAGE             MEMORY   VCPUS  ARGS                                 BOOT TIME
-opentelemetry-collector-bvtnh        running  since 11mins  opentelemetry...  976 MiB  1      /usr/bin/otelcontribcol --config...  177.62 ms
+NAME                           FQDN  STATE    STATUS        IMAGE             MEMORY    VCPUS  ARGS                                 BOOT TIME
+opentelemetry-collector-bvtnh        running  since 11mins  opentelemetry...  1536 MiB  1      /usr/bin/otelcontribcol --config...  177.62 ms
 ```
 
 When done, you can remove the instance:

--- a/python3.12-flask3.0-sqlite/README.md
+++ b/python3.12-flask3.0-sqlite/README.md
@@ -24,7 +24,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 -M 512 .
+kraft cloud deploy -p 443:8080 -M 768 .
 ```
 
 ```ansi
@@ -36,7 +36,7 @@ kraft cloud deploy -p 443:8080 -M 512 .
  ├─────────── url: https://lingering-orangutan-840mmdvd.fra.unikraft.app
  ├───────── image: python312-flask30-sqlite@sha256:bdb0bf35a9675b9b3836cbb626606da0606334d91768c7ba31195c3062d6f517
  ├───── boot time: 166.25 ms
- ├──────── memory: 512 MiB
+ ├──────── memory: 768 MiB
  ├─────── service: lingering-orangutan-840mmdvd
  ├── private fqdn: python312-flask30-sqlite-qodkd.internal
  ├──── private ip: 172.16.3.3
@@ -79,7 +79,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                            FQDN                                           STATE    STATUS        IMAGE                               MEMORY   VCPUS  ARGS                             BOOT TIME
-python312-flask30-sqlite-qodkd  lingering-orangutan-840mmdvd.fra.unikraft.app  running  1 minute ago  python312-flask30-sqlite@sha256...  512 MiB  1      /usr/bin/python3 /app/server.py  166250us
+python312-flask30-sqlite-qodkd  lingering-orangutan-840mmdvd.fra.unikraft.app  running  1 minute ago  python312-flask30-sqlite@sha256...  768 MiB  1      /usr/bin/python3 /app/server.py  166250us
 ```
 
 When done, you can remove the instance:

--- a/skipper/README.md
+++ b/skipper/README.md
@@ -25,7 +25,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:9090 .
+kraft cloud deploy -p 443:9090 -M 256 .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://aged-sea-o7d3c42s.fra.unikraft.app
  ├───────── image: skipper@sha256:5483eaf3612cca2116ceaab9be42557686324f1d30337ae15d0495eef63d0386
  ├───── boot time: 43.71 ms
- ├──────── memory: 128 MiB
+ ├──────── memory: 256 MiB
  ├─────── service: aged-sea-o7d3c42s
  ├── private fqdn: skipper-mx4ai.internal
  ├──── private ip: 172.16.6.4
@@ -65,7 +65,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME           FQDN                                STATE    STATUS        IMAGE                      MEMORY   VCPUS  ARGS                                          BOOT TIME
-skipper-mx4ai  aged-sea-o7d3c42s.fra.unikraft.app  running  1 minute ago  skipper@sha256:5483eaf...  128 MiB  1      /usr/bin/skipper -address :9090 -routes-f...  43709us
+skipper-mx4ai  aged-sea-o7d3c42s.fra.unikraft.app  running  1 minute ago  skipper@sha256:5483eaf...  256 MiB  1      /usr/bin/skipper -address :9090 -routes-f...  43709us
 ```
 
 When done, you can remove the instance:

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -27,7 +27,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 2048 .
+kraft cloud deploy -p 443:3000 -M 4096 .
 ```
 
 The output shows the instance address and other details:
@@ -41,7 +41,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://damp-bobo-wg43p36e.fra.unikraft.app
  ├───────── image: spin-wagi-http@sha256:57a5151996d83332af6da521e1cd92271a8c3ac7ae26bc44a7c0dbbc0a30e577
  ├───── boot time: 300.06 ms
- ├──────── memory: 2048 MiB
+ ├──────── memory: 4096 MiB
  ├─────── service: damp-bobo-wg43p36e
  ├── private fqdn: spin-wagi-http-is72r.internal
  ├──── private ip: 172.16.28.16
@@ -74,7 +74,7 @@ kraft cloud instance list
 ```
 ```ansi
 NAME                  FQDN                                 STATE    STATUS        IMAGE                   MEMORY   VCPUS  ARGS                                      BOOT TIME
-spin-wagi-http-is72r  damp-bobo-wg43p36e.fra.unikraft.app  running  1 minute ago  spin-wagi-http@sha2...  2.0 GiB  1      /usr/bin/spin up --from /app/spin.tom...  300064us
+spin-wagi-http-is72r  damp-bobo-wg43p36e.fra.unikraft.app  running  1 minute ago  spin-wagi-http@sha2...  4.0 GiB  1      /usr/bin/spin up --from /app/spin.tom...  300064us
 ```
 
 When done, you can remove the instance:

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -25,7 +25,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -M 512 -p 443:80/tls+http -p 8080:8080/tls .
+kraft cloud deploy -M 1024 -p 443:80/tls+http -p 8080:8080/tls .
 ```
 
 The output shows the instance address and other details:
@@ -39,7 +39,7 @@ The output shows the instance address and other details:
  ├─────────── url: https://holy-cherry-rye39b1x.fra.unikraft.app
  ├───────── image: traefik@sha256:f6dd913a81f6a057ceb9db7844222d7287b2a83f668cca88c73c2e85554cb526
  ├───── boot time: 53.66 ms
- ├──────── memory: 512 MiB
+ ├──────── memory: 1024 MiB
  ├─────── service: holy-cherry-rye39b1x
  ├── private fqdn: traefik-wqe7e.internal
  ├──── private ip: 172.16.28.16
@@ -70,8 +70,8 @@ You can list information about the instance by running:
 kraft cloud instance list
 ```
 ```ansi
-NAME           FQDN                                   STATE    STATUS         IMAGE                        MEMORY   VCPUS  ARGS                                           BOOT TIME
-traefik-wqe7e  holy-cherry-rye39b1x.fra.unikraft.app  running  8 minutes ago  traefik@sha256:f6dd913a8...  512 MiB  1      /usr/bin/traefik -configFile /etc/traefik/...  53661us
+NAME           FQDN                                   STATE    STATUS         IMAGE                        MEMORY    VCPUS  ARGS                                           BOOT TIME
+traefik-wqe7e  holy-cherry-rye39b1x.fra.unikraft.app  running  8 minutes ago  traefik@sha256:f6dd913a8...  1024 MiB  1      /usr/bin/traefik -configFile /etc/traefik/...  53661us
 ```
 
 When done, you can remove the instance:

--- a/vnc-browser/README.md
+++ b/vnc-browser/README.md
@@ -32,7 +32,7 @@ kraft cloud deploy \
     --scale-to-zero on \
     --scale-to-zero-stateful \
     --scale-to-zero-cooldown 4s \
-    -M 2048 \
+    -M 4096 \
     -p 443:6080 \
     -n vnc-browser \
     .
@@ -49,7 +49,7 @@ The output shows the instance address and other details:
  ├────── state: starting
  ├───── domain: https://weathered-fog-y5jjmwfd.fra.unikraft.app
  ├────── image: vnc-browser@sha256:fdb4887e84362ebbaf54c713e0d85f547e8ee173fe63a6ab39e94b7e612a9892 
- ├───── memory: 2048 MiB
+ ├───── memory: 4096 MiB
  ├──── service: weathered-fog-y5jjmwfd
  ├─ private ip: 10.0.0.49
  └─────── args: /wrapper.sh

--- a/wazero-import-go/README.md
+++ b/wazero-import-go/README.md
@@ -25,7 +25,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:8080 . /age-calculator 2000
+kraft cloud deploy -p 443:8080 -p 512 . /age-calculator 2000
 ```
 
 The output shows the instance address and other details:

--- a/wordpress-all-in-one/README.md
+++ b/wordpress-all-in-one/README.md
@@ -29,7 +29,7 @@ export UKC_METRO=fra
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash
-kraft cloud deploy -p 443:3000 -M 3072 .
+kraft cloud deploy -p 443:3000 -M 4096 .
 ```
 
 The output shows the instance address and other details:
@@ -42,7 +42,7 @@ The output shows the instance address and other details:
  ├───────── state: starting
  ├──────── domain: https://cool-silence-h5c1es4z.fra.unikraft.app
  ├───────── image: wordpress@sha256:3e116e6c74dd04e19d4062a14f8173974ba625179ace3c10a2c96546638c4cd8
- ├──────── memory: 3072 MiB
+ ├──────── memory: 4096 MiB
  ├─────── service: cool-silence-h5c1es4z
  ├── private fqdn: wordpress-fx5rb.internal
  ├──── private ip: 172.16.3.1
@@ -63,7 +63,7 @@ kraft cloud inst list
 
 ```ansi
 NAME             FQDN                                    STATE    STATUS       IMAGE                 MEMORY   VCPUS  ARGS                       BOOT TIME
-wordpress-fx5rb  cool-silence-h5c1es4z.fra.unikraft.app  running  since 2mins  wordpress@sha256:...  3.0 GiB  1      /usr/local/bin/wrapper.sh  1708.17 ms
+wordpress-fx5rb  cool-silence-h5c1es4z.fra.unikraft.app  running  since 2mins  wordpress@sha256:...  4.0 GiB  1      /usr/local/bin/wrapper.sh  1708.17 ms
 ```
 
 When done, you can remove the instance:


### PR DESCRIPTION
Update README.md files to feature correct memory values. Current values are sometimes to small and result in an out-of-memory error when deploying examples on Unikraft Cloud.

Memory values are correct in GitHub workflows (where available), so there is no need to update them.