### PR TITLE
feat: Introduce simple Perl5.42 HTTP server

### DIFF
--- a/.github/workflows/example-http-perl5.42-stable.yaml
+++ b/.github/workflows/example-http-perl5.42-stable.yaml
@@ -1,0 +1,79 @@
+name: examples/http-perl5.42 (stable)
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-perl5.42-stable.yaml'
+    - 'http-perl5.42/**'
+    - '!http-perl5.42/README.md'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-perl5.42-stable.yaml'
+    - 'http-perl5.42/**'
+    - '!http-perl5.42/README.md'
+
+  schedule:
+  - cron: '15 15 * * 1-5'
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STABLE }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      id: test
+      uses: unikraft/kraftkit@staging
+      env:
+        UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+      with:
+        run: |
+          set -xe;
+
+          cd http-perl5.42;
+
+          kraft cloud deploy \
+            --no-start \
+            --memory 512 \
+            --name http-perl542-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-testing/base-compat:latest \
+            --subdomain http-perl542-${GITHUB_RUN_ID} \
+            -p 443:8080 \
+            .;
+
+          # wait for the instance to start
+          kraft cloud vm start -w 5s http-perl542-${GITHUB_RUN_ID};
+          sleep 5;
+
+          curl -Lv --fail-with-body --max-time 10 https://http-perl542-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STABLE }}.unikraft.app
+
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+
+          kraft cloud vm stop http-perl542-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs http-perl542-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm http-perl542-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/http-perl542-${GITHUB_RUN_ID} || true;

--- a/.github/workflows/example-http-perl5.42-staging.yaml
+++ b/.github/workflows/example-http-perl5.42-staging.yaml
@@ -1,0 +1,79 @@
+name: examples/http-perl5.42 (staging)
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-perl5.42-staging.yaml'
+    - 'http-perl5.42/**'
+    - '!http-perl5.42/README.md'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - '.github/workflows/example-http-perl5.42-staging.yaml'
+    - 'http-perl5.42/**'
+    - '!http-perl5.42/README.md'
+
+  schedule:
+  - cron: '15 15 * * 1-5'
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STAGING }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      id: test
+      uses: unikraft/kraftkit@staging
+      env:
+        UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+      with:
+        run: |
+          set -xe;
+
+          cd http-perl5.42;
+
+          kraft cloud deploy \
+            --no-start \
+            --memory 512 \
+            --name http-perl542-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-staging/base-compat:latest \
+            --subdomain http-perl542-${GITHUB_RUN_ID} \
+            -p 443:8080 \
+            .;
+
+          # wait for the instance to start
+          kraft cloud vm start -w 5s http-perl542-${GITHUB_RUN_ID};
+          sleep 5;
+
+          curl -Lv --fail-with-body --max-time 10 https://http-perl542-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STAGING }}.unikraft.app
+
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+
+          kraft cloud vm stop http-perl542-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs http-perl542-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm http-perl542-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/http-perl542-${GITHUB_RUN_ID} || true;

--- a/http-perl5.42/Dockerfile
+++ b/http-perl5.42/Dockerfile
@@ -1,0 +1,23 @@
+FROM perl:5.42.0-bookworm AS build
+
+RUN set -xe ; \
+    cpanm HTTP::Daemon
+
+FROM scratch
+
+# Perl binary
+COPY --from=build /usr/local/bin/perl /usr/bin/perl
+
+# Perl libraries
+COPY --from=build /usr/local/lib/perl5 /usr/local/lib/perl5
+
+# System libraries
+COPY --from=build /usr/local/lib/perl5/5.42.0/x86_64-linux-gnu/CORE/libperl.so /usr/local/lib/perl5/5.42.0/x86_64-linux-gnu/CORE/libperl.so
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
+
+# Simple Perl HTTP server
+COPY ./server.pl /usr/src/server.pl

--- a/http-perl5.42/Kraftfile
+++ b/http-perl5.42/Kraftfile
@@ -1,0 +1,12 @@
+spec: v0.6
+
+runtime: base-compat:latest
+
+labels:
+  cloud.unikraft.v1.instances/scale_to_zero.policy: "on"
+  cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
+  cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
+
+rootfs: ./Dockerfile
+
+cmd: ["/usr/bin/perl", "/usr/src/server.pl"]

--- a/http-perl5.42/README.md
+++ b/http-perl5.42/README.md
@@ -1,0 +1,111 @@
+# Perl
+
+This guide explains how to create and deploy a simple Perl-based HTTP web server.
+To run this example, follow these steps:
+
+1. Install the [`kraft` CLI tool](https://unikraft.org/docs/cli/install) and a container runtime engine, for example [Docker](https://docs.docker.com/engine/install/).
+
+2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/http-perl5.42/` directory:
+
+```bash
+git clone https://github.com/unikraft-cloud/examples
+cd examples/http-perl5.42/
+```
+
+Make sure to log into Unikraft Cloud by setting your token and a [metro](https://unikraft.com/docs/platform/metros) close to you.
+This guide uses `fra` (Frankfurt, 🇩🇪):
+
+```bash
+export UKC_TOKEN=token
+# Set metro to Frankfurt, DE
+export UKC_METRO=fra
+```
+
+When done, invoke the following command to deploy this app on Unikraft Cloud:
+
+```bash
+kraft cloud deploy -p 443:8080 -M 512 .
+```
+
+The output shows the instance address and other details:
+
+```ansi
+[●] Deployed successfully!
+ │
+ ├────── name: http-perl542-xue8j
+ ├────── uuid: 59d08bbc-cbb7-4c6b-a2cb-847828845db9
+ ├───── metro: fra
+ ├───── state: running
+ ├──── domain: https://fragrant-water-wau08gaw.fra.unikraft.app
+ ├───── image: http-perl542@sha256:af86e8f03c0d4cfd596ccfd9a9d18ea75ac68c996c9cde31f64db24dc11100fe
+ ├─ boot time: 109.36 ms
+ ├──── memory: 512 MiB
+ ├─── service: fragrant-water-wau08gaw
+ ├ private ip: 10.0.1.161
+ └────── args: /usr/bin/perl /usr/src/server.pl
+```
+
+In this case, the instance name is `http-perl542-xue8j` and the address is `https://fragrant-water-wau08gaw.fra.unikraft.app`.
+They're different for each run.
+
+Use `curl` to query the Unikraft Cloud instance of the Perl-based HTTP web server:
+
+```bash
+curl https://fragrant-water-wau08gaw.fra.unikraft.app
+```
+```text
+Hello, World!
+```
+
+You can list information about the instance by running:
+
+```bash
+kraft cloud instance list
+```
+```ansi
+NAME                FQDN                                      STATE    STATUS   IMAGE                                                             MEMORY   VCPUS  ARGS                              BOOT TIME
+http-perl542-xue8j  fragrant-water-wau08gaw.fra.unikraft.app  standby  standby  http-perl542@sha256:af86e8f03c0d4cfd596ccfd9a9d18e...             512 MiB  1      /usr/bin/perl /usr/src/server.pl  109.46 ms
+```
+
+When you list your instances, you might notice they show as standby. This is normal behavior and means the instance is using Unikraft Cloud's scale-to-zero feature that saves resources when there is no traffic.
+To check your instance is working properly you can open two terminals and use these commands to watch the status:
+
+```bash
+watch -n 1 "kraft cloud instance list"
+# In another terminal, make requests
+curl https://fragrant-water-wau08gaw.fra.unikraft.app
+```
+
+It briefly switches to "running" then back to "standby".
+
+When done, you can remove the instance:
+
+```bash
+kraft cloud instance remove http-perl542-xue8j
+```
+
+## Customize your app
+
+To customize the app, update the files in the repository, listed below:
+
+* `server.pl`: the actual Perl HTTP server
+* `Kraftfile`: the Unikraft Cloud specification
+* `Dockerfile`: the Docker-specified app filesystem
+
+The following options are available for customizing the app:
+
+* If you only update the implementation in the `server.pl` source file, you don't need to make any other changes.
+
+* If you create any new source files, copy them into the app filesystem by using the `COPY` command in the `Dockerfile`.
+
+* More extensive changes may require extending the `Dockerfile` ([see `Dockerfile` syntax reference](https://docs.docker.com/engine/reference/builder/)).
+
+## Learn more
+
+Use the `--help` option for detailed information on using Unikraft Cloud:
+
+```bash
+kraft cloud --help
+```
+
+Or visit the [CLI Reference](https://unikraft.com/docs/cli/overview).

--- a/http-perl5.42/server.pl
+++ b/http-perl5.42/server.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+
+use HTTP::Daemon;
+use HTTP::Status;
+use HTTP::Response;
+
+my $d = HTTP::Daemon->new(
+    LocalAddr => '0.0.0.0',
+    LocalPort => 8080,
+) or die;
+
+while (my $client_connection = $d->accept) {
+    my $request = $client_connection->get_request;
+    my $response = HTTP::Response->new(200);
+    $response->content("Hello, World!\n");
+    $client_connection->send_response($response);
+}


### PR DESCRIPTION
Introduce simple Perl5.42 HTTP server to be deployed on Unikraft Cloud. It uses binary compatibility mode (i.e. the `perl:5.42` image).

Add:

* `Kraftfile`: build / run rules, including pulling the `perl` image
* `Dockerfile`: Perl filesystem, including binaries and libraries
* `README.md`: document how to use
* `server.pl`: the HTTP server implementation