### PR TITLE
feat(workflows): Add workflows for Grafana example

### DIFF
--- a/.github/workflows/example-grafana-stable.yaml
+++ b/.github/workflows/example-grafana-stable.yaml
@@ -1,0 +1,74 @@
+name: examples/grafana (stable)
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [ada-dev1419/grafana]
+    paths:
+    - '.github/workflows/example-grafana-stable.yaml'
+    - 'grafana/**'
+    - '!grafana/README.md'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - '.github/workflows/example-grafana-stable.yaml'
+    - 'grafana/**'
+    - '!grafana/README.md'
+
+  schedule:
+  - cron: '0 15 * * 1-5'
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STABLE }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      id: test
+      uses: unikraft/kraftkit@staging
+      with:
+        run: |
+          set -xe;
+          cd grafana;
+          kraft cloud deploy \
+            --no-start \
+            --scale-to-zero on \
+            --scale-to-zero-stateful \
+            --scale-to-zero-cooldown 4s \
+            --memory 2048 \
+            --name grafana-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-testing/base-compat:latest \
+            --subdomain grafana-${GITHUB_RUN_ID} \
+            -p 443:3000 \
+            .;
+          # wait for the instance to start
+          kraft cloud vm start -w 5s grafana-${GITHUB_RUN_ID};
+          sleep 5;
+          curl -Lv --fail-with-body --max-time 10 https://grafana-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STABLE }}.unikraft.app
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+          kraft cloud vm stop grafana-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs grafana-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm grafana-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/grafana-${GITHUB_RUN_ID} || true;

--- a/.github/workflows/example-grafana-staging.yaml
+++ b/.github/workflows/example-grafana-staging.yaml
@@ -1,0 +1,71 @@
+name: examples/grafana (staging)
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [ada-dev1419/grafana]
+    paths:
+    - '.github/workflows/example-grafana-staging.yaml'
+    - 'grafana/**'
+    - '!grafana/README.md'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+    - '.github/workflows/example-grafana-staging.yaml'
+    - 'grafana/**'
+    - '!grafana/README.md'
+
+  schedule:
+  - cron: '0 15 * * 1-5'
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STAGING }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      id: test
+      uses: unikraft/kraftkit@staging
+      with:
+        run: |
+          set -xe;
+          cd grafana;
+          kraft cloud deploy \
+            --no-start \
+            --memory 2048 \
+            --name grafana-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-staging/base-compat:latest \
+            --subdomain grafana-${GITHUB_RUN_ID} \
+            -p 443:3000 \
+            .;
+          # wait for the instance to start
+          kraft cloud vm start -w 5s grafana-${GITHUB_RUN_ID};
+          sleep 5;
+          curl -Lv --fail-with-body --max-time 10 https://grafana-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STAGING }}.unikraft.app
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+          kraft cloud vm stop grafana-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs grafana-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm grafana-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/grafana-${GITHUB_RUN_ID} || true;


### PR DESCRIPTION
Add stable and staging workflows for Grafana example, based on example-caddy-* workflows.
Tested locally with success using "kraft cloud deploy -p 443:3000 -M 2048 .".