### PR TITLE
fix(examples): Ensure /run/sshd is owned by root:root on macOS

### DIFF
--- a/httpserver-c-debug/Dockerfile
+++ b/httpserver-c-debug/Dockerfile
@@ -27,6 +27,7 @@ COPY --from=build /etc/group /etc/group
 
 # Basic binaries
 COPY --from=build /usr/sbin/sshd /usr/sbin/sshd
+COPY --from=build /usr/bin/chown /usr/bin/chown
 COPY --from=build /usr/bin/strace /usr/bin/strace
 COPY --from=build /usr/bin/netstat /usr/bin/netstat
 COPY --from=build /usr/bin/su /usr/bin/su

--- a/httpserver-c-debug/wrapper.sh
+++ b/httpserver-c-debug/wrapper.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+chown root:root /run/sshd
+
 # Start SSH server.
 export HOME=/root
 


### PR DESCRIPTION
A known issue on Docker for mac (https://github.com/docker/for-mac/issues/1814) previously caused /run/sshd to be owned by 501:dialout, which causes the instance to stop.

Resolves issue #263