### PR TITLE
chore: Ensure all examples use the base-compat:latest runtime

### DIFF
--- a/httpserver-java17-springboot3.2.x/README.md
+++ b/httpserver-java17-springboot3.2.x/README.md
@@ -97,7 +97,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: java:17`: The Unikraft runtime kernel to use is Java.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-nginx-vite-vanilla/Dockerfile
+++ b/httpserver-nginx-vite-vanilla/Dockerfile
@@ -8,6 +8,38 @@ RUN set -xe; \
     npm ci; \
     npm run build
 
+FROM nginx:1.25.3-bookworm AS nginx
+
+RUN set -xe; \
+    rm -f /var/log/nginx/access.log; \
+    rm -f /var/log/nginx/error.log; \
+    touch /var/log/nginx/access.log; \
+    touch /var/log/nginx/error.log \
+    ;
+
 FROM scratch
+
+# Nginx binaries, modules, configuration, log and runtime files
+COPY --from=nginx /usr/sbin/nginx /usr/bin/nginx
+COPY --from=nginx /usr/lib/nginx /usr/lib/nginx
+COPY --from=nginx /etc/nginx /etc/nginx
+COPY --from=nginx /etc/passwd /etc/passwd
+COPY --from=nginx /etc/group /etc/group
+COPY --from=nginx /var/log/nginx /var/log/nginx
+COPY --from=nginx /var/cache/nginx /var/cache/nginx
+COPY --from=nginx /var/run /var/run
+
+# Libraries
+COPY --from=nginx /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+COPY --from=nginx /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
+COPY --from=nginx /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=nginx /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=nginx /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=nginx /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=nginx /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=nginx /etc/ld.so.cache /etc/ld.so.cache
+
+# Custom configuration files, including using a single process for Nginx
+COPY ./rootfs/ /
 
 COPY --from=build /app/dist /wwwroot

--- a/httpserver-nginx-vite-vanilla/Kraftfile
+++ b/httpserver-nginx-vite-vanilla/Kraftfile
@@ -2,7 +2,7 @@ spec: v0.6
 
 name: nginx-vite-vanilla
 
-runtime: nginx:latest
+runtime: base-compat:latest
 
 labels:
   cloud.unikraft.v1.instances/scale_to_zero.policy: "on"

--- a/httpserver-nginx-vite-vanilla/README.md
+++ b/httpserver-nginx-vite-vanilla/README.md
@@ -126,7 +126,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: nginx:latest`: The nginx kernel to use.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-nginx-vite-vanilla/rootfs/etc/nginx/nginx.conf
+++ b/httpserver-nginx-vite-vanilla/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes  1;
+daemon            off;
+master_process    off;
+user root root;
+
+events {
+  worker_connections  64;
+}
+
+http {
+  include mime.types;
+  default_type application/octet-stream;
+
+  open_file_cache           max=10000 inactive=30s;
+  open_file_cache_min_uses  2;
+  open_file_cache_errors    on;
+
+  error_log stderr error;
+  access_log off;
+
+  keepalive_timeout     10s;
+  keepalive_requests    10000;
+  send_timeout          10s;
+
+  server {
+    listen              8080;
+    server_name         localhost;
+    root                /wwwroot;
+    index               index.html;
+  }
+}

--- a/httpserver-nginx-vite-vanilla/rootfs/wwwroot/index.html
+++ b/httpserver-nginx-vite-vanilla/rootfs/wwwroot/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>

--- a/httpserver-node21-nextjs/README.md
+++ b/httpserver-node21-nextjs/README.md
@@ -115,7 +115,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: node:21`: The Unikraft runtime kernel to use is Node 21.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-node21-sveltekit/README.md
+++ b/httpserver-node21-sveltekit/README.md
@@ -159,7 +159,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: node:21`: The Unikraft runtime kernel to use is Node 21.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-python3.12-django5.0/README.md
+++ b/httpserver-python3.12-django5.0/README.md
@@ -136,7 +136,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: python:3.12`: The Unikraft runtime kernel to use is Python 3.12.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-python3.12-flask3.0-sqlite/README.md
+++ b/httpserver-python3.12-flask3.0-sqlite/README.md
@@ -132,7 +132,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: python:3.12`: The Unikraft runtime kernel to use is Python 3.12.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-python3.12-flask3.0/README.md
+++ b/httpserver-python3.12-flask3.0/README.md
@@ -114,7 +114,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: python:3.12`: The Unikraft runtime kernel to use is Python 3.12.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-python3.12/README.md
+++ b/httpserver-python3.12/README.md
@@ -114,7 +114,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: python:3.12`: The Unikraft runtime kernel to use is Python 3.12.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/httpserver-rust-trunkrs-leptos/Dockerfile
+++ b/httpserver-rust-trunkrs-leptos/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.0-slim-bullseye AS builder
+FROM rust:1.88.0-slim-bullseye AS builder
 RUN rustup target add wasm32-unknown-unknown && cargo install wasm-bindgen-cli && cargo install --locked trunk
 
 # Set up the working directory in the container
@@ -17,9 +17,42 @@ RUN trunk build --config ./frontend/Trunk.toml --release
 
 EXPOSE 8080
 
+FROM nginx:1.25.3-bookworm AS nginx
+
+RUN set -xe; \
+    rm -f /var/log/nginx/access.log; \
+    rm -f /var/log/nginx/error.log; \
+    touch /var/log/nginx/access.log; \
+    touch /var/log/nginx/error.log \
+    ;
+
 # Use a smaller base image for the final runtime
 # FROM nginx:1.27.4-alpine
 FROM scratch
+
+# Nginx binaries, modules, configuration, log and runtime files
+COPY --from=nginx /usr/sbin/nginx /usr/bin/nginx
+COPY --from=nginx /usr/lib/nginx /usr/lib/nginx
+COPY --from=nginx /etc/nginx /etc/nginx
+COPY --from=nginx /etc/passwd /etc/passwd
+COPY --from=nginx /etc/group /etc/group
+COPY --from=nginx /var/log/nginx /var/log/nginx
+COPY --from=nginx /var/cache/nginx /var/cache/nginx
+COPY --from=nginx /var/run /var/run
+
+# Libraries
+COPY --from=nginx /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
+COPY --from=nginx /lib/x86_64-linux-gnu/libpcre2-8.so.0 /lib/x86_64-linux-gnu/libpcre2-8.so.0
+COPY --from=nginx /lib/x86_64-linux-gnu/libssl.so.3 /lib/x86_64-linux-gnu/libssl.so.3
+COPY --from=nginx /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
+COPY --from=nginx /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
+COPY --from=nginx /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=nginx /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=nginx /etc/ld.so.cache /etc/ld.so.cache
+
+# Custom configuration files, including using a single process for Nginx
+COPY ./rootfs/ /
+
 COPY --from=builder /usr/src/frontend/frontend/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /usr/src/frontend/frontend/dist /usr/share/nginx/html/
 

--- a/httpserver-rust-trunkrs-leptos/Kraftfile
+++ b/httpserver-rust-trunkrs-leptos/Kraftfile
@@ -1,6 +1,6 @@
 spec: v0.6
 
-runtime: nginx:latest
+runtime: base-compat:latest
 
 labels:
   cloud.unikraft.v1.instances/scale_to_zero.policy: "on"

--- a/httpserver-rust-trunkrs-leptos/rootfs/rootfs/etc/nginx/nginx.conf
+++ b/httpserver-rust-trunkrs-leptos/rootfs/rootfs/etc/nginx/nginx.conf
@@ -1,0 +1,31 @@
+worker_processes  1;
+daemon            off;
+master_process    off;
+user root root;
+
+events {
+  worker_connections  64;
+}
+
+http {
+  include mime.types;
+  default_type application/octet-stream;
+
+  open_file_cache           max=10000 inactive=30s;
+  open_file_cache_min_uses  2;
+  open_file_cache_errors    on;
+
+  error_log stderr error;
+  access_log off;
+
+  keepalive_timeout     10s;
+  keepalive_requests    10000;
+  send_timeout          10s;
+
+  server {
+    listen              8080;
+    server_name         localhost;
+    root                /wwwroot;
+    index               index.html;
+  }
+}

--- a/httpserver-rust-trunkrs-leptos/rootfs/rootfs/wwwroot/index.html
+++ b/httpserver-rust-trunkrs-leptos/rootfs/rootfs/wwwroot/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+    body {
+        width: 35em;
+        margin: 0 auto;
+        font-family: Tahoma, Verdana, Arial, sans-serif;
+    }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>

--- a/imaginary/README.md
+++ b/imaginary/README.md
@@ -127,7 +127,7 @@ You can customize the command line options used to start the service, by updatin
 ```yaml
 spec: v0.6
 
-runtime: imaginary:1.2
+runtime: base-compat:latest
 
 cmd: ["/usr/bin/imaginary", "-p", "8080"]
 ```

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -143,7 +143,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: ruby:3.2`: The Unikraft runtime kernel to use is Ruby 3.2.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -125,7 +125,7 @@ Lines in the `Kraftfile` have the following roles:
 
 * `spec: v0.6`: The current `Kraftfile` specification version is `0.6`.
 
-* `runtime: spin:latest`: The Unikraft runtime kernel to use is Spin.
+* `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
 * `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
 


### PR DESCRIPTION
This runtime is best for examples and prototyping as it is a compatibility runtime which reduces friction in starting new applications.

This commit also contains changes to the Dockerfiles to ensure that the rootfs contains everything which was in the initramfs bundled with the previous runtime.

Closes: #268