### PR TITLE
fix(elixir): Copy system binaries from runtime stage, not build stage

### DIFF
--- a/httpserver-elixir1.16/Dockerfile
+++ b/httpserver-elixir1.16/Dockerfile
@@ -58,6 +58,10 @@ COPY --from=runtime /usr/bin/dirname \
                     /usr/bin/basename \
                     /usr/bin/readlink \
                     /usr/bin/env \
+                    /usr/bin/cut \
+                    /usr/bin/sed \
+                    /usr/bin/cat \
+                    /usr/bin/grep \
                     /usr/bin/
 
 COPY --from=runtime /bin/rm \
@@ -73,9 +77,5 @@ COPY --from=build /src/_build /src/_build
 COPY --from=build /src/lib /src/lib
 COPY --from=build /src/mix.exs /src/mix.exs
 COPY --from=build /src/mix.lock /src/mix.lock
-COPY --from=build /usr/bin/cut /usr/bin/cut
-COPY --from=build /usr/bin/sed /usr/bin/sed
-COPY --from=build /usr/bin/cat /usr/bin/cat
-COPY --from=build /usr/bin/grep /usr/bin/grep
 
 COPY ./wrapper.sh /usr/bin/wrapper.sh

--- a/httpserver-elixir1.16/mix.exs
+++ b/httpserver-elixir1.16/mix.exs
@@ -7,7 +7,12 @@ defmodule Server.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      releases: [
+        server: [
+          include_erts: false
+        ]
+      ]
     ]
   end
 


### PR DESCRIPTION
The build stage runs on the BUILDPLATFORM so using binaries copied from there would crash the application when there is an architecture mismatch between the build host and the target.

Whereas the runtime stage runs on the TARGETPLATFORM so it will not suffer from such an architecture mismatch.

Also take the Erlang runtime from the runtime stage