### PR TITLE
fix(spring-petclinic): Fix JDK packaging

### DIFF
--- a/.github/workflows/example-httpserver-java17-spring-petclinic-stable.yaml
+++ b/.github/workflows/example-httpserver-java17-spring-petclinic-stable.yaml
@@ -59,7 +59,7 @@ jobs:
             -p 443:8080 \
             .;
           # wait for the instance to start
-          kraft cloud vm start -w 5s httpserver-java17-spring-petclinic-${GITHUB_RUN_ID};
+          kraft cloud vm start -w 10s httpserver-java17-spring-petclinic-${GITHUB_RUN_ID};
           sleep 5;
           curl -Lv --fail-with-body --max-time 10 https://httpserver-java17-spring-petclinic-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STABLE }}.unikraft.app
     - name: Cleanup

--- a/.github/workflows/example-httpserver-java17-spring-petclinic-staging.yaml
+++ b/.github/workflows/example-httpserver-java17-spring-petclinic-staging.yaml
@@ -59,7 +59,7 @@ jobs:
             -p 443:8080 \
             .;
           # wait for the instance to start
-          kraft cloud vm start -w 5s httpserver-java17-spring-petclinic-${GITHUB_RUN_ID};
+          kraft cloud vm start -w 10s httpserver-java17-spring-petclinic-${GITHUB_RUN_ID};
           sleep 5;
           curl -Lv --fail-with-body --max-time 10 https://httpserver-java17-spring-petclinic-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STAGING }}.unikraft.app
     - name: Cleanup

--- a/httpserver-java17-spring-petclinic/Dockerfile
+++ b/httpserver-java17-spring-petclinic/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM debian:bookworm AS build
+FROM --platform=linux/x86_64 debian:bookworm AS build
 
 RUN set -xe ; \
     apt -yqq update ; \
@@ -18,6 +18,9 @@ RUN git checkout -b build ${BUILD_COMMIT}
 
 RUN --mount=type=cache,target=/root/.m2 ./mvnw package
 
+RUN rm -f /usr/lib/jvm/java-17-openjdk-amd64/lib/src.zip && \
+    cp -rL /usr/lib/jvm/java-17-openjdk-amd64/ /jvm-resolved/
+
 FROM scratch
 
 COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
@@ -28,7 +31,7 @@ COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libg
 COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
 
-COPY --from=build /usr/lib/jvm/java-17-openjdk-amd64/ /usr/lib/jvm/java-17-openjdk-amd64/
+COPY --from=build /jvm-resolved/ /usr/lib/jvm/java-17-openjdk-amd64/
 COPY --from=build /etc/ssl/certs/java/cacerts /etc/ssl/certs/java/cacerts
 
 COPY --from=build /etc/java-17-openjdk/security/ /etc/java-17-openjdk/security/


### PR DESCRIPTION
Resolve symlinks before creating initramfs to prevent failure at the unikraft build stage

Additionally ensure build occurs on linux/x86_64 platform to ensure the amd64 java 17 JDK paths are present