### PR TITLE
fix(minio): Always build from linux/x86_64 platform

### DIFF
--- a/minio/Dockerfile
+++ b/minio/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4-alpine3.17 AS build
+FROM --platform=linux/x86_64 golang:1.21.4-alpine3.17 AS build
 
 RUN set -xe; \
     apk --no-cache add \


### PR DESCRIPTION
This fixes the example on macOS