### PR TITLE
fix(node24-karaoke): Decrease rootfs size

### DIFF
--- a/node24-karaoke/Dockerfile
+++ b/node24-karaoke/Dockerfile
@@ -19,19 +19,31 @@ RUN set -xe; \
     pnpm exec playwright install; \
     pnpm build
 
-# FROM scratch
-FROM node:24-bookworm-slim AS prod
+# Install serve globally for use as static file server
+RUN npm install -g serve
 
-# Node binary
+FROM scratch
+
+# System binaries
 COPY --from=build /usr/local/bin/node /usr/local/bin/node
+COPY --from=build /bin/sh /bin/sh
+COPY --from=build /usr/bin/env /usr/bin/env
 
-# System libraries
-COPY --from=build /lib/x86_64-linux-gnu /lib/x86_64-linux-gnu
+# serve (static file server)
+COPY --from=build /usr/local/lib/node_modules/serve /usr/local/lib/node_modules/serve
+
+# Required system libraries
+COPY --from=build /lib/x86_64-linux-gnu/libdl.so.2 /lib/x86_64-linux-gnu/libdl.so.2
+COPY --from=build /lib/x86_64-linux-gnu/libstdc++.so.6 /lib/x86_64-linux-gnu/libstdc++.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libm.so.6 /lib/x86_64-linux-gnu/libm.so.6
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libgcc_s.so.1
+COPY --from=build /lib/x86_64-linux-gnu/libpthread.so.0 /lib/x86_64-linux-gnu/libpthread.so.0
+COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
+COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+COPY --from=build /etc/ld.so.cache /etc/ld.so.cache
 
 # Distribution configuration
 COPY --from=build /etc/os-release /etc/os-release
-
-COPY --from=build /usr/src /usr/src
 
 COPY --from=build /allkaraoke/build /wwwroot
 

--- a/node24-karaoke/entrypoint.sh
+++ b/node24-karaoke/entrypoint.sh
@@ -1,3 +1,2 @@
-#!/bin/bash
-
-yes | npx serve -s /wwwroot -p 8080
+#!/bin/sh
+exec node /usr/local/lib/node_modules/serve/build/main.js -s /wwwroot -p 8080


### PR DESCRIPTION
By using a "FROM scratch" directive to prevent
copying the entire node24 layer, and only copying
over the system libraries we need, the rootfs
is shrunk a lot.

This prevents the instance immediately stopping
when it is created.