### PR TITLE
fix(debian-ssh): Ensure /run/sshd owned by root:root

### DIFF
--- a/debian-ssh/wrapper.sh
+++ b/debian-ssh/wrapper.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+chown root:root /run/sshd
+
 # Start SSH server.
 export HOME=/root
 


### PR DESCRIPTION
This guarantees that /run/sshd is owned by root:root which is required for sshd to run.