### PR TITLE
fix(spring-petclinic): Build from linux/x86_64 platform

### DIFF
--- a/httpserver-java17-spring-petclinic/Dockerfile
+++ b/httpserver-java17-spring-petclinic/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM debian:bookworm AS build
+FROM --platform=linux/x86_64 debian:bookworm AS build
 
 RUN set -xe ; \
     apt -yqq update ; \


### PR DESCRIPTION
This enables the build to work on platforms which do not have the *x86_64* paths which are copied into the rootfs.