### PR TITLE
fix(examples): Run Chromium as single process

### DIFF
--- a/node-playwright-chromium/server.js
+++ b/node-playwright-chromium/server.js
@@ -16,7 +16,12 @@ const requestListener = function (request, response) {
         // Anonymous function to call Playwright
         (async () => {
             try {
-                const browser = await chromium.launch({headless: true});
+                const browser = await chromium.launch({
+                    headless: true,
+                    args: [
+                        '--single-process',
+                    ],
+                });
                 const page = await browser.newPage();
                 await page.goto(remote);
                 const buffer = await page.screenshot();

--- a/python-playwright-chromium/main.py
+++ b/python-playwright-chromium/main.py
@@ -12,7 +12,9 @@ async def screenshot_page(page: str | None = None):
     try:
         url = f"{page}"
         playwright = await async_playwright().start()
-        browser = await playwright.chromium.launch()
+        browser = await playwright.chromium.launch(args=[
+            '--single-process',
+        ])
         page = await browser.new_page()
         await page.goto(url)
         buffer = await page.screenshot()


### PR DESCRIPTION
This workaround stops the node-playwright-chromium and python-playwright-chromium examples from crashing.