### PR TITLE
fix(wordpress-all-in-one): Listen on correct port

### DIFF
--- a/wordpress-all-in-one/rootfs/etc/nginx/nginx.conf
+++ b/wordpress-all-in-one/rootfs/etc/nginx/nginx.conf
@@ -24,7 +24,7 @@ http {
   client_max_body_size 13m;
 
   server {
-    listen              80;
+    listen              3000;
     server_name         localhost;
     root                /var/www/html;
     index               index.php index.html index.htm;


### PR DESCRIPTION
Configure the nginx server to listen on the port
which is used in the commands in the README.md.