### PR TITLE
fix(examples): Added --image flag for unikraft run

### DIFF
--- a/caddy2.7-go1.21/README.md
+++ b/caddy2.7-go1.21/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/caddy27-go121:latest
-unikraft run --metro=fra -p 443:2015/http+tls -m 256M <my-org>/caddy27-go121:latest
+unikraft run --metro fra -p 443:2015/http+tls -m 256M --image <my-org>/caddy27-go121:latest
 ```
 
 or

--- a/debian-ssh/README.md
+++ b/debian-ssh/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/debian-ssh:latest
-unikraft run --metro=fra -p 2222:2222/tls -m 1G -e PUBKEY="...." <my-org>/debian-ssh:latest
+unikraft run --metro fra -p 2222:2222/tls -m 1G -e PUBKEY="...." --image <my-org>/debian-ssh:latest
 ```
 
 or

--- a/dragonflydb/README.md
+++ b/dragonflydb/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/dragonflydb:latest
-unikraft run --metro=fra -p 443:6379/http+tls -m 512M <my-org>/dragonflydb:latest
+unikraft run --metro fra -p 443:6379/http+tls -m 512M --image <my-org>/dragonflydb:latest
 ```
 
 or

--- a/duckdb-go1.21/README.md
+++ b/duckdb-go1.21/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/duckdb-go1.21:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/duckdb-go1.21:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/duckdb-go1.21:latest
 ```
 
 or

--- a/github-webhook-node/README.md
+++ b/github-webhook-node/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/github-webhook-node:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 1G -e GITHUB_WEBHOOK_SECRET=your_secret_here <my-org>/github-webhook-node:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 1G -e GITHUB_WEBHOOK_SECRET=your_secret_here --image <my-org>/github-webhook-node:latest
 ```
 
 or

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/grafana:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 2G <my-org>/grafana:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 2G --image <my-org>/grafana:latest
 ```
 
 or

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/haproxy:latest
-unikraft run --metro=fra -p 443:8404/tls+http -m 256M <my-org>/haproxy:latest
+unikraft run --metro fra -p 443:8404/tls+http -m 256M --image <my-org>/haproxy:latest
 ```
 
 or

--- a/httpserver-boost1.74-gpp13.2/README.md
+++ b/httpserver-boost1.74-gpp13.2/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-boost1.74-gpp13.2:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-boost1.74-gpp13.2:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-boost1.74-gpp13.2:latest
 ```
 
 or

--- a/httpserver-bun/README.md
+++ b/httpserver-bun/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-bun:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 512M <my-org>/httpserver-bun:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-bun:latest
 ```
 
 or

--- a/httpserver-c-debug/README.md
+++ b/httpserver-c-debug/README.md
@@ -33,7 +33,7 @@ For extensive debug information with `strace`, add the `USE_STRACE=1` environmen
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-c-debug:latest
-unikraft run --metro=fra -p 443:8080/tls+http -p 2222:2222/tls -e PUBKEY=.... -e USE_STRACE=1 -m 256M <my-org>/httpserver-c-debug:latest
+unikraft run --metro fra -p 443:8080/tls+http -p 2222:2222/tls -e PUBKEY=.... -e USE_STRACE=1 -m 256M --image <my-org>/httpserver-c-debug:latest
 ```
 
 or

--- a/httpserver-dotnet10.0/README.md
+++ b/httpserver-dotnet10.0/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-dotnet10.0:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-dotnet10.0:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-dotnet10.0:latest
 ```
 
 or

--- a/httpserver-elixir1.16/README.md
+++ b/httpserver-elixir1.16/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-elixir1.16:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 1G <my-org>/httpserver-elixir1.16:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 1G --image <my-org>/httpserver-elixir1.16:latest
 ```
 
 or

--- a/httpserver-erlang26.2/README.md
+++ b/httpserver-erlang26.2/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-erlang26.2:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-erlang26.2:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-erlang26.2:latest
 ```
 
 or

--- a/httpserver-expressjs4.18-node21/README.md
+++ b/httpserver-expressjs4.18-node21/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-expressjs4.18-node21:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 512M <my-org>/httpserver-expressjs4.18-node21:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-expressjs4.18-node21:latest
 ```
 
 or

--- a/httpserver-gcc13.2/README.md
+++ b/httpserver-gcc13.2/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-gcc13.2:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-gcc13.2:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-gcc13.2:latest
 ```
 
 or

--- a/httpserver-go1.21/README.md
+++ b/httpserver-go1.21/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-go1.21:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-go1.21:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-go1.21:latest
 ```
 
 or

--- a/httpserver-gpp13.2/README.md
+++ b/httpserver-gpp13.2/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-gpp13.2:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-gpp13.2:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-gpp13.2:latest
 ```
 
 or

--- a/httpserver-java17-spring-petclinic/README.md
+++ b/httpserver-java17-spring-petclinic/README.md
@@ -7,7 +7,7 @@ Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-java17-spring-petclinic:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 1G <my-org>/httpserver-java17-spring-petclinic:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/httpserver-java17-spring-petclinic:latest
 ```
 
 or

--- a/httpserver-java17-springboot3.5.x/README.md
+++ b/httpserver-java17-springboot3.5.x/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-java17-springboot3.5.x:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 1G <my-org>/httpserver-java17-springboot3.5.x:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/httpserver-java17-springboot3.5.x:latest
 ```
 
 or

--- a/httpserver-java21/README.md
+++ b/httpserver-java21/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-java21:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 1G <my-org>/httpserver-java21:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/httpserver-java21:latest
 ```
 
 or

--- a/httpserver-lua5.1/README.md
+++ b/httpserver-lua5.1/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-lua5.1:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-lua5.1:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-lua5.1:latest
 ```
 
 or

--- a/httpserver-nginx-vite-vanilla/README.md
+++ b/httpserver-nginx-vite-vanilla/README.md
@@ -36,7 +36,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-nginx-vite-vanilla:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-nginx-vite-vanilla:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-nginx-vite-vanilla:latest
 ```
 
 or

--- a/httpserver-node-express-puppeteer/README.md
+++ b/httpserver-node-express-puppeteer/README.md
@@ -41,7 +41,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node-express-puppeteer:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 4G <my-org>/httpserver-node-express-puppeteer:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 4G --image <my-org>/httpserver-node-express-puppeteer:latest
 ```
 
 or

--- a/httpserver-node-vite-ssr-vanilla/README.md
+++ b/httpserver-node-vite-ssr-vanilla/README.md
@@ -22,7 +22,7 @@ To deploy, `cd` into this directory and run:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node-vite-ssr-vanilla:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 1G -e PWD=/app -e NODE_ENV=production <my-org>/httpserver-node-vite-ssr-vanilla:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 1G -e PWD=/app -e NODE_ENV=production --image <my-org>/httpserver-node-vite-ssr-vanilla:latest
 ```
 
 or

--- a/httpserver-node-vite-vanilla/README.md
+++ b/httpserver-node-vite-vanilla/README.md
@@ -26,7 +26,7 @@ To deploy, `cd` into this directory and run:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node-vite-vanilla:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 4G -e PWD=/app <my-org>/httpserver-node-vite-vanilla:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 4G -e PWD=/app --image <my-org>/httpserver-node-vite-vanilla:latest
 ```
 
 or

--- a/httpserver-node21-nextjs/README.md
+++ b/httpserver-node21-nextjs/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node21-nextjs:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 768M <my-org>/httpserver-node21-nextjs:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 768M --image <my-org>/httpserver-node21-nextjs:latest
 ```
 
 or
@@ -154,7 +154,7 @@ Run the command below to deploy the app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-expressjs4.18-node21:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 256M <my-org>/httpserver-expressjs4.18-node21:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 256M --image <my-org>/httpserver-expressjs4.18-node21:latest
 ```
 
 or

--- a/httpserver-node21-remix/README.md
+++ b/httpserver-node21-remix/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node21-remix:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 768M <my-org>/httpserver-node21-remix:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 768M --image <my-org>/httpserver-node21-remix:latest
 ```
 
 or

--- a/httpserver-node21-solid-start/README.md
+++ b/httpserver-node21-solid-start/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node21-solid-start:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 512M <my-org>/httpserver-node21-solid-start:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-node21-solid-start:latest
 ```
 
 or

--- a/httpserver-node21-sveltekit/README.md
+++ b/httpserver-node21-sveltekit/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node21-sveltekit:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 512M <my-org>/httpserver-node21-sveltekit:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-node21-sveltekit:latest
 ```
 
 or

--- a/httpserver-node25/README.md
+++ b/httpserver-node25/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node25:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-node25:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-node25:latest
 ```
 
 or

--- a/httpserver-perl5.42/README.md
+++ b/httpserver-perl5.42/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-perl5.42:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-perl5.42:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-perl5.42:latest
 ```
 
 or

--- a/httpserver-php8.2/README.md
+++ b/httpserver-php8.2/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-php8.2:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-php8.2:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-php8.2:latest
 ```
 
 or

--- a/httpserver-prisma-expressjs4.19-node18/README.md
+++ b/httpserver-prisma-expressjs4.19-node18/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-prisma-expressjs4.19-node18:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 512M <my-org>/httpserver-prisma-expressjs4.19-node18:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-prisma-expressjs4.19-node18:latest
 ```
 
 or

--- a/httpserver-python3.12-django5.0/README.md
+++ b/httpserver-python3.12-django5.0/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12-django5.0:latest
-unikraft run --metro=fra -p 443:80/tls+http -m 1G <my-org>/httpserver-python3.12-django5.0:latest
+unikraft run --metro fra -p 443:80/tls+http -m 1G --image <my-org>/httpserver-python3.12-django5.0:latest
 ```
 
 or
@@ -167,7 +167,7 @@ Run the command below to deploy the app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12-django5.0:latest
-unikraft run --metro=fra -p 443:80/tls+http -m 1G <my-org>/httpserver-python3.12-django5.0:latest
+unikraft run --metro fra -p 443:80/tls+http -m 1G --image <my-org>/httpserver-python3.12-django5.0:latest
 ```
 
 or

--- a/httpserver-python3.12-fastapi-0.121.3/README.md
+++ b/httpserver-python3.12-fastapi-0.121.3/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12-fastapi-0.121.3:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-python3.12-fastapi-0.121.3:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python3.12-fastapi-0.121.3:latest
 ```
 
 or
@@ -144,7 +144,7 @@ Run the command below to deploy the app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12-fastapi-0.121.3:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-python3.12-fastapi-0.121.3:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python3.12-fastapi-0.121.3:latest
 ```
 
 or

--- a/httpserver-python3.12-flask3.0-sqlite/README.md
+++ b/httpserver-python3.12-flask3.0-sqlite/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12-flask3.0-sqlite:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 768M <my-org>/httpserver-python3.12-flask3.0-sqlite:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 768M --image <my-org>/httpserver-python3.12-flask3.0-sqlite:latest
 ```
 
 or

--- a/httpserver-python3.12-flask3.0/README.md
+++ b/httpserver-python3.12-flask3.0/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12-flask3.0:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-python3.12-flask3.0:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python3.12-flask3.0:latest
 ```
 
 or

--- a/httpserver-python3.12/README.md
+++ b/httpserver-python3.12/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-python3.12:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python3.12:latest
 ```
 
 or
@@ -147,7 +147,7 @@ Run the command below to deploy the app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python3.12:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/httpserver-python3.12:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python3.12:latest
 ```
 
 or

--- a/httpserver-ruby3.2/README.md
+++ b/httpserver-ruby3.2/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-ruby3.2:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-ruby3.2:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-ruby3.2:latest
 ```
 
 or

--- a/httpserver-rust-trunkrs-leptos/README.md
+++ b/httpserver-rust-trunkrs-leptos/README.md
@@ -5,7 +5,7 @@ Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust-trunkrs-leptos:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-rust-trunkrs-leptos:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust-trunkrs-leptos:latest
 ```
 
 or

--- a/httpserver-rust1.75-tokio/README.md
+++ b/httpserver-rust1.75-tokio/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust1.75-tokio:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-rust1.75-tokio:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust1.75-tokio:latest
 ```
 
 or

--- a/httpserver-rust1.81-rocket0.5/README.md
+++ b/httpserver-rust1.81-rocket0.5/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust1.81-rocket0.5:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-rust1.81-rocket0.5:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust1.81-rocket0.5:latest
 ```
 
 or
@@ -93,13 +93,13 @@ httpserver-rust181-rocket05-tuwq3  empty-bobo-n3htmpye.fra.unikraft.app  running
 When done, you can remove the instance:
 
 ```bash title="unikraft"
-unikraft instances delete httpserver-rust181-rocket05-tuwq3 
+unikraft instances delete httpserver-rust181-rocket05-tuwq3
 ```
 
 or
 
 ```bash title="kraft"
-kraft cloud instance remove httpserver-rust181-rocket05-tuwq3 
+kraft cloud instance remove httpserver-rust181-rocket05-tuwq3
 ```
 
 ## Customize your app

--- a/httpserver-rust1.87-actix-web4/README.md
+++ b/httpserver-rust1.87-actix-web4/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust1.87-actix-web4:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/httpserver-rust1.87-actix-web4:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust1.87-actix-web4:latest
 ```
 
 or

--- a/httpserver-rust1.91/README.md
+++ b/httpserver-rust1.91/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust1.91:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 384M <my-org>/httpserver-rust1.91:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 384M --image <my-org>/httpserver-rust1.91:latest
 ```
 
 or

--- a/hugo0.122/README.md
+++ b/hugo0.122/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/hugo0.122:latest
-unikraft run --metro=fra -p 443:1313/tls+http -m 512M <my-org>/hugo0.122:latest
+unikraft run --metro fra -p 443:1313/tls+http -m 512M --image <my-org>/hugo0.122:latest
 ```
 
 or

--- a/imaginary/README.md
+++ b/imaginary/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/imaginary:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/imaginary:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/imaginary:latest
 ```
 
 or

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mariadb:latest
-unikraft run --metro=fra -p 3306:3306/tls -m 1G -e MARIADB_ROOT_PASSWORD="unikraft" <my-org>/mariadb:latest
+unikraft run --metro fra -p 3306:3306/tls -m 1G -e MARIADB_ROOT_PASSWORD="unikraft" --image <my-org>/mariadb:latest
 ```
 
 or
@@ -151,7 +151,7 @@ Then start the MariaDB instance and mount that volume:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mariadb:latest
-unikraft run --metro=fra -p 3306:3306/tls -m 1G -e MARIADB_ROOT_PASSWORD="unikraft" --volume mariadb-store:/var/lib <my-org>/mariadb:latest
+unikraft run --metro fra -p 3306:3306/tls -m 1G -e MARIADB_ROOT_PASSWORD="unikraft" --volume mariadb-store:/var/lib --image <my-org>/mariadb:latest
 ```
 
 or

--- a/mcp-server-arxiv/README.md
+++ b/mcp-server-arxiv/README.md
@@ -46,7 +46,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mcp-server-arxiv:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 2G <my-org>/mcp-server-arxiv:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 2G --image <my-org>/mcp-server-arxiv:latest
 ```
 
 or
@@ -134,7 +134,7 @@ Then start the MCP server instance and mount that volume (while specifying the s
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mcp-server-arxiv:latest
-unikraft run --metro=fra -v mcp-server-arxiv-data:/volume -p 443:8080/tls+http -m 2G <my-org>/mcp-server-arxiv:latest -- "/usr/local/bin/python /src/server.py --storage-path /volume"
+unikraft run --metro fra -v mcp-server-arxiv-data:/volume -p 443:8080/tls+http -m 2G --image <my-org>/mcp-server-arxiv:latest -- "/usr/local/bin/python /src/server.py --storage-path /volume"
 ```
 
 or

--- a/mcp-server-simple/README.md
+++ b/mcp-server-simple/README.md
@@ -38,7 +38,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mcp-server-simple:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/mcp-server-simple:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/mcp-server-simple:latest
 ```
 
 or

--- a/memcached1.6/README.md
+++ b/memcached1.6/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/memcached1.6:latest
-unikraft run --metro=fra -p 11211:11211/tls -m 256M <my-org>/memcached1.6:latest
+unikraft run --metro fra -p 11211:11211/tls -m 256M --image <my-org>/memcached1.6:latest
 ```
 
 or

--- a/minio/README.md
+++ b/minio/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/minio:latest
-unikraft run --metro=fra -p 443:9001/tls+http -p 9000:9000/tls -m 512M <my-org>/minio:latest
+unikraft run --metro fra -p 443:9001/tls+http -p 9000:9000/tls -m 512M --image <my-org>/minio:latest
 ```
 
 or

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mongodb:latest
-unikraft run --metro=fra -p 27017:27017/tls -m 1G <my-org>/mongodb:latest
+unikraft run --metro fra -p 27017:27017/tls -m 1G --image <my-org>/mongodb:latest
 ```
 
 or
@@ -133,7 +133,7 @@ Then start the MongoDB instance and mount that volume:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mongodb:latest
-unikraft run --metro=fra -p 27017:27017/tls -m 1G --volume mongodb-store:/data/db <my-org>/mongodb:latest
+unikraft run --metro fra -p 27017:27017/tls -m 1G --volume mongodb-store:/data/db --image <my-org>/mongodb:latest
 ```
 
 or

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/nginx:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 256M <my-org>/nginx:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/nginx:latest
 ```
 
 or

--- a/node-playwright-chromium/README.md
+++ b/node-playwright-chromium/README.md
@@ -7,7 +7,7 @@ Then clone this repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-playwright-chromium:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 4G <my-org>/node-playwright-chromium:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/node-playwright-chromium:latest
 ```
 
 or

--- a/node-playwright-firefox/README.md
+++ b/node-playwright-firefox/README.md
@@ -7,7 +7,7 @@ Then clone this repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-playwright-firefox:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 4G <my-org>/node-playwright-firefox:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/node-playwright-firefox:latest
 ```
 
 or

--- a/node-playwright-webkit/README.md
+++ b/node-playwright-webkit/README.md
@@ -7,7 +7,7 @@ Then clone this repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-playwright-webkit:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 4G <my-org>/node-playwright-webkit:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/node-playwright-webkit:latest
 ```
 
 or

--- a/node18-agario/README.md
+++ b/node18-agario/README.md
@@ -7,7 +7,7 @@ Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node18-agario:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 1G <my-org>/node18-agario:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 1G --image <my-org>/node18-agario:latest
 ```
 
 or

--- a/node18-wingsio/README.md
+++ b/node18-wingsio/README.md
@@ -7,7 +7,7 @@ Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node18-wingsio:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 1G <my-org>/node18-wingsio:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 1G --image <my-org>/node18-wingsio:latest
 ```
 
 or

--- a/node21-websocket/README.md
+++ b/node21-websocket/README.md
@@ -8,7 +8,7 @@ Then clone this examples repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node21-websocket:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 1G <my-org>/node21-websocket:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/node21-websocket:latest
 ```
 
 or

--- a/node24-karaoke/README.md
+++ b/node24-karaoke/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node24-karaoke:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 2G <my-org>/node24-karaoke:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 2G --image <my-org>/node24-karaoke:latest
 ```
 
 or

--- a/novnc-browser/README.md
+++ b/novnc-browser/README.md
@@ -37,7 +37,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/novnc-browser:latest
-unikraft run --scale-to-zero policy=on,cooldown-time=4000,stateful=true --metro=fra -p 443:6080/tls+http -m 4G <my-org>/novnc-browser:latest
+unikraft run --scale-to-zero policy=on,cooldown-time=4000,stateful=true --metro fra -p 443:6080/tls+http -m 4G --image <my-org>/novnc-browser:latest
 ```
 
 or

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -36,7 +36,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/opentelemetry-collector:latest
-unikraft run --metro=fra -p 443:4318/tls+http -m 1536M <my-org>/opentelemetry-collector:latest
+unikraft run --metro fra -p 443:4318/tls+http -m 1536M --image <my-org>/opentelemetry-collector:latest
 ```
 
 or

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/postgres:latest
-unikraft run --metro=fra -p 5432:5432/tls -m 1G -e POSTGRES_PASSWORD=unikraft <my-org>/postgres:latest
+unikraft run --metro fra -p 5432:5432/tls -m 1G -e POSTGRES_PASSWORD=unikraft --image <my-org>/postgres:latest
 ```
 
 or
@@ -146,7 +146,7 @@ Then start the PostgreSQL instance and mount that volume:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/postgres:latest
-unikraft run --metro=fra -p 5432:5432/tls -m 1G -e POSTGRES_PASSWORD=unikraft -e PGDATA=/volume/postgres --volume postgres:/volume <my-org>/postgres:latest
+unikraft run --metro fra -p 5432:5432/tls -m 1G -e POSTGRES_PASSWORD=unikraft -e PGDATA=/volume/postgres --volume postgres:/volume --image <my-org>/postgres:latest
 ```
 
 or

--- a/python-playwright-chromium/README.md
+++ b/python-playwright-chromium/README.md
@@ -7,7 +7,7 @@ Then clone this repository and `cd` into this directory, and invoke:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/python-playwright-chromium:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 4G <my-org>/python-playwright-chromium:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/python-playwright-chromium:latest
 ```
 
 or

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -33,7 +33,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/ruby3.2-rails:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 1G -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle <my-org>/ruby3.2-rails:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 1G -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle --image <my-org>/ruby3.2-rails:latest
 ```
 
 or

--- a/skipper0.18/README.md
+++ b/skipper0.18/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/skipper0.18:latest
-unikraft run --metro=fra -p 443:9090/tls+http -m 256M <my-org>/skipper0.18:latest
+unikraft run --metro fra -p 443:9090/tls+http -m 256M --image <my-org>/skipper0.18:latest
 ```
 
 or

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -36,7 +36,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/spin-wagi-http:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 4G <my-org>/spin-wagi-http:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 4G --image <my-org>/spin-wagi-http:latest
 ```
 
 or

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/traefik:latest
-unikraft run --metro=fra -p 443:80/tls+http -p 8080:8080/tls -m 1G <my-org>/traefik:latest
+unikraft run --metro fra -p 443:80/tls+http -p 8080:8080/tls -m 1G --image <my-org>/traefik:latest
 ```
 
 or

--- a/visual-studio-code-server/README.md
+++ b/visual-studio-code-server/README.md
@@ -39,7 +39,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 unikraft volume create --set metro=fra --set name=code-workspace --set size=1G
 
 unikraft build . --output <my-org>/visual-studio-code-server:latest
-unikraft run --metro=fra -p 443:8443/tls+http -m 2G --volume code-workspace:/workspace --scale-to-zero policy=on,cooldown-time=4000,stateful=true -e PGUID=0 -e PGID=0 -e PASSWORD=unikraft -e SUDO_PASSWORD=unikraft -e DEFAULT_WORKSPACE="/workspace" <my-org>/visual-studio-code-server:latest
+unikraft run --metro fra -p 443:8443/tls+http -m 2G --volume code-workspace:/workspace --scale-to-zero policy=on,cooldown-time=4000,stateful=true -e PGUID=0 -e PGID=0 -e PASSWORD=unikraft -e SUDO_PASSWORD=unikraft -e DEFAULT_WORKSPACE="/workspace" --image <my-org>/visual-studio-code-server:latest
 ```
 
 or

--- a/vsftpd/README.md
+++ b/vsftpd/README.md
@@ -35,7 +35,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 unikraft volume create --set metro=fra --set name=vsftpd-workspace --set size=1G
 
 unikraft build . --output <my-org>/vsftpd:latest
-unikraft run --metro=fra --scale-to-zero policy=on,cooldown-time=40000,stateful=true -p 20:20/tls -p 21:21/tls -p 222:22/tls -p 990:990/tls -p 10100:10100/tls -m 1G --volume vsftpd-workspace:/root <my-org>/vsftpd:latest
+unikraft run --metro fra --scale-to-zero policy=on,cooldown-time=40000,stateful=true -p 20:20/tls -p 21:21/tls -p 222:22/tls -p 990:990/tls -p 10100:10100/tls -m 1G --volume vsftpd-workspace:/root --image <my-org>/vsftpd:latest
 ```
 
 or

--- a/wazero-import-go/README.md
+++ b/wazero-import-go/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/wazero-import-go:latest
-unikraft run --metro=fra -p 443:8080/tls+http -m 512M <my-org>/wazero-import-go:latest
+unikraft run --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/wazero-import-go:latest
 ```
 
 or

--- a/wordpress-all-in-one/README.md
+++ b/wordpress-all-in-one/README.md
@@ -34,7 +34,7 @@ When done, invoke the following command to deploy this app on Unikraft Cloud:
 
 ```bash title="unikraft"
 unikraft build . --output <my-org>/wordpress-all-in-one:latest
-unikraft run --metro=fra -p 443:3000/tls+http -m 4G <my-org>/wordpress-all-in-one:latest
+unikraft run --metro fra -p 443:3000/tls+http -m 4G --image <my-org>/wordpress-all-in-one:latest
 ```
 
 or


### PR DESCRIPTION
The examples don't work with unikraft 0.2.2. The image only works by passing it via the `--image` flag.

```
unikraft run --metro=fra -p 443:3000/tls+http -m 4G dragosgheorghioiu/nginx:latest
│
│ error:
│   parsing arguments: unexpected argument dragosgheorghioiu/nginx:latest
│
```