### PR TITLE
FIELD-326: chore: Change rootfs type to EROFS

### DIFF
--- a/basic-ops/Kraftfile
+++ b/basic-ops/Kraftfile
@@ -4,6 +4,8 @@ name: httpserver-c
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/caddy2.7-go1.21/Kraftfile
+++ b/caddy2.7-go1.21/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/debian-ssh/Kraftfile
+++ b/debian-ssh/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh"]

--- a/dragonflydb/Kraftfile
+++ b/dragonflydb/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh"]

--- a/duckdb-go1.21/Kraftfile
+++ b/duckdb-go1.21/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/feature-change-instance-cmd/Kraftfile
+++ b/feature-change-instance-cmd/Kraftfile
@@ -4,6 +4,8 @@ name: httpserver-c
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/github-webhook-node/Kraftfile
+++ b/github-webhook-node/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "node", "/app/server.js" ]

--- a/grafana/Kraftfile
+++ b/grafana/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/share/grafana/bin/grafana", "server", "-homepath", "/usr/share/grafana/"]

--- a/haproxy/Kraftfile
+++ b/haproxy/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/haproxy", "-f", "/etc/haproxy/haproxy.conf"]

--- a/httpserver-boost1.74-gpp13.2/Kraftfile
+++ b/httpserver-boost1.74-gpp13.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/httpserver-boost1.74-gpp13.2/README.md
+++ b/httpserver-boost1.74-gpp13.2/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base`: The Unikraft runtime kernel to use is its base one.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/http_server"]`: Use `/http_server` as the starting command of the instance.
 

--- a/httpserver-bun/Kraftfile
+++ b/httpserver-bun/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/bun", "run", "/usr/src/server.ts"]

--- a/httpserver-bun/README.md
+++ b/httpserver-bun/README.md
@@ -115,7 +115,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/bun", "run", "/usr/src/server.ts"]`: Use `/usr/bin/bun run /usr/src/server.ts` as the starting command of the instance.
 

--- a/httpserver-c-debug/Kraftfile
+++ b/httpserver-c-debug/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh"]

--- a/httpserver-dotnet10.0/Kraftfile
+++ b/httpserver-dotnet10.0/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/app/src"]

--- a/httpserver-dotnet10.0/README.md
+++ b/httpserver-dotnet10.0/README.md
@@ -115,7 +115,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd:`: Use as the starting command of the instance.
 

--- a/httpserver-elixir1.16/Kraftfile
+++ b/httpserver-elixir1.16/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 3000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "_build/dev/rel/server/bin/server", "start"]

--- a/httpserver-erlang26.2/Kraftfile
+++ b/httpserver-erlang26.2/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/erl", "-noshell", "-s", "http_server"]

--- a/httpserver-expressjs4.18-node21/Kraftfile
+++ b/httpserver-expressjs4.18-node21/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-expressjs4.18-node21/README.md
+++ b/httpserver-expressjs4.18-node21/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/node", "/usr/src/server.js"]`: Use `/usr/bin/node /usr/src/server.js` as the starting command of the instance.
 

--- a/httpserver-flask-redis/Kraftfile
+++ b/httpserver-flask-redis/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/app/app.py"]

--- a/httpserver-gcc13.2/Kraftfile
+++ b/httpserver-gcc13.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/httpserver-go1.21/Kraftfile
+++ b/httpserver-go1.21/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-go1.22-redis/Kraftfile
+++ b/httpserver-go1.22-redis/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-gpp13.2/Kraftfile
+++ b/httpserver-gpp13.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/httpserver-gpp13.2/README.md
+++ b/httpserver-gpp13.2/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base`: The Unikraft runtime kernel to use is its base one.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/http_server"]`: Use `/http_server` as the starting command of the instance.
 

--- a/httpserver-java17-spring-petclinic/Kraftfile
+++ b/httpserver-java17-spring-petclinic/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/spring-petclinic-3.3.0-SNAPSHOT.jar"]
 

--- a/httpserver-java17-springboot3.5.x/Kraftfile
+++ b/httpserver-java17-springboot3.5.x/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/demo-0.0.1-SNAPSHOT.jar"]
 

--- a/httpserver-java17-springboot3.5.x/README.md
+++ b/httpserver-java17-springboot3.5.x/README.md
@@ -99,7 +99,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/demo-0.0.1-SNAPSHOT.jar"]`: Use as the starting command of the instance.
 

--- a/httpserver-java21/Kraftfile
+++ b/httpserver-java21/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 # Path updated from Java 17 to Java 21
 cmd: ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "-classpath", "/usr/src/", "SimpleHttpServer"]

--- a/httpserver-java21/README.md
+++ b/httpserver-java21/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "-classpath", "/usr/src/", "SimpleHttpServer"]`: Use the Java runtime to run `SimpleHttpServer` as the starting command of the instance.
 

--- a/httpserver-lua5.1/Kraftfile
+++ b/httpserver-lua5.1/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/lua", "/http_server.lua"]

--- a/httpserver-nginx-vite-vanilla/Kraftfile
+++ b/httpserver-nginx-vite-vanilla/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/httpserver-nginx-vite-vanilla/README.md
+++ b/httpserver-nginx-vite-vanilla/README.md
@@ -128,7 +128,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]`: Use nginx to serve the built static files as the starting command of the instance.
 

--- a/httpserver-node-express-puppeteer/Kraftfile
+++ b/httpserver-node-express-puppeteer/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/bin/www"]

--- a/httpserver-node-vite-ssr-vanilla/Kraftfile
+++ b/httpserver-node-vite-ssr-vanilla/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 2000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["node", "/app/server.js"]

--- a/httpserver-node-vite-vanilla/Kraftfile
+++ b/httpserver-node-vite-vanilla/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 2000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["npm", "run", "dev"]

--- a/httpserver-node21-nextjs/Kraftfile
+++ b/httpserver-node21-nextjs/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-node21-nextjs/README.md
+++ b/httpserver-node21-nextjs/README.md
@@ -117,7 +117,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: [["/usr/bin/node", "/usr/src/server.js"]]`: Use `/usr/bin/node /usr/src/server.js` as the starting command of the instance.
 

--- a/httpserver-node21-remix/Kraftfile
+++ b/httpserver-node21-remix/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-node21-solid-start/Kraftfile
+++ b/httpserver-node21-solid-start/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server/index.mjs"]

--- a/httpserver-node21-sveltekit/Kraftfile
+++ b/httpserver-node21-sveltekit/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/app/build/index.js"]

--- a/httpserver-node21-sveltekit/README.md
+++ b/httpserver-node21-sveltekit/README.md
@@ -161,7 +161,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: [["/usr/bin/node", "/app/build/index.js"]]`: Use `/usr/bin/node /app/build/index.js` as the starting command of the instance.
 

--- a/httpserver-node25/Kraftfile
+++ b/httpserver-node25/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-node25/README.md
+++ b/httpserver-node25/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/node", "/usr/src/server.js"]`: Use `/usr/bin/node /usr/src/server.js` as the starting command of the instance.
 

--- a/httpserver-perl5.42/Kraftfile
+++ b/httpserver-perl5.42/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/perl", "/usr/src/server.pl"]

--- a/httpserver-php8.2/Kraftfile
+++ b/httpserver-php8.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/php /usr/src/server.php"]

--- a/httpserver-prisma-expressjs4.19-node18/Kraftfile
+++ b/httpserver-prisma-expressjs4.19-node18/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-python3.12-django5.0/Kraftfile
+++ b/httpserver-python3.12-django5.0/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/app/main.py"]

--- a/httpserver-python3.12-django5.0/README.md
+++ b/httpserver-python3.12-django5.0/README.md
@@ -138,7 +138,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/app/main.py"]`: Use this as the starting command of the instance.
 

--- a/httpserver-python3.12-fastapi-0.121.3/Kraftfile
+++ b/httpserver-python3.12-fastapi-0.121.3/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/httpserver-python3.12-fastapi-0.121.3/README.md
+++ b/httpserver-python3.12-fastapi-0.121.3/README.md
@@ -115,7 +115,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The Unikraft runtime kernel to use is the latest that provides a minimal Linux-compatible environment.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]`: Use this as the starting command of the instance.
 

--- a/httpserver-python3.12-flask3.0-sqlite/Kraftfile
+++ b/httpserver-python3.12-flask3.0-sqlite/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/app/server.py"]

--- a/httpserver-python3.12-flask3.0-sqlite/README.md
+++ b/httpserver-python3.12-flask3.0-sqlite/README.md
@@ -134,7 +134,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/app/server.py"]`: Use `/usr/bin/python3 /app/server.py` as the starting command of the instance.
 

--- a/httpserver-python3.12-flask3.0/Kraftfile
+++ b/httpserver-python3.12-flask3.0/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/src/server.py"]

--- a/httpserver-python3.12-flask3.0/README.md
+++ b/httpserver-python3.12-flask3.0/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/src/server.py"]`: Use `/usr/bin/python3 /src/server.py` as the starting command of the instance.
 

--- a/httpserver-python3.12/Kraftfile
+++ b/httpserver-python3.12/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/src/server.py"]

--- a/httpserver-python3.12/README.md
+++ b/httpserver-python3.12/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/src/server.py"]`: Use `/usr/bin/python3 /src/server.py` as the starting command of the instance.
 

--- a/httpserver-ruby3.2/Kraftfile
+++ b/httpserver-ruby3.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/ruby", "/src/server.rb"]

--- a/httpserver-rust-trunkrs-leptos/Kraftfile
+++ b/httpserver-rust-trunkrs-leptos/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/httpserver-rust1.75-tokio/Kraftfile
+++ b/httpserver-rust1.75-tokio/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-rust1.81-rocket0.5/Kraftfile
+++ b/httpserver-rust1.81-rocket0.5/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-rust1.87-actix-web4/Kraftfile
+++ b/httpserver-rust1.87-actix-web4/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-rust1.91/Kraftfile
+++ b/httpserver-rust1.91/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/hugo0.122/Kraftfile
+++ b/hugo0.122/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/hugo", "server", "--bind=0.0.0.0", "--source", "/site"]

--- a/imaginary/Kraftfile
+++ b/imaginary/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/imaginary", "-p", "8080"]

--- a/mariadb/Kraftfile
+++ b/mariadb/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh"]

--- a/mcp-server-arxiv/Kraftfile
+++ b/mcp-server-arxiv/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/usr/local/bin/python", "/src/server.py" ]

--- a/mcp-server-simple/Kraftfile
+++ b/mcp-server-simple/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/usr/bin/python3", "/src/server.py" ]

--- a/memcached1.6/Kraftfile
+++ b/memcached1.6/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/memcached", "-u", "root"]

--- a/minio/Kraftfile
+++ b/minio/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [
   "/usr/bin/minio",

--- a/mongodb/Kraftfile
+++ b/mongodb/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/mongod", "--bind_ip_all", "--nounixsocket"]

--- a/nginx-flask-mongo/flask/Kraftfile
+++ b/nginx-flask-mongo/flask/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   # cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "python", "/app/server.py" ]

--- a/nginx-flask-mongo/nginx/Kraftfile
+++ b/nginx-flask-mongo/nginx/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "nginx" ]

--- a/nginx/Kraftfile
+++ b/nginx/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/node-playwright-chromium/Kraftfile
+++ b/node-playwright-chromium/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/server.js"]

--- a/node-playwright-firefox/Kraftfile
+++ b/node-playwright-firefox/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/server.js"]

--- a/node-playwright-firefox/redis7.2/Kraftfile
+++ b/node-playwright-firefox/redis7.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/redis-server", "/etc/redis/redis.conf"]

--- a/node-playwright-webkit/Kraftfile
+++ b/node-playwright-webkit/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/server.js"]

--- a/node18-agario/Kraftfile
+++ b/node18-agario/Kraftfile
@@ -9,7 +9,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 2000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["node", "/usr/src/app/bin/server/server.js"]
 

--- a/node18-wingsio/Kraftfile
+++ b/node18-wingsio/Kraftfile
@@ -9,7 +9,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1500
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["node", "/usr/src/app/server.js"]
 

--- a/node21-websocket/Kraftfile
+++ b/node21-websocket/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/node24-karaoke/README.md
+++ b/node24-karaoke/README.md
@@ -126,7 +126,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/entrypoint.sh"]`: Use `/entrypoint.sh` as the starting command of the instance.
 

--- a/novnc-browser/Kraftfile
+++ b/novnc-browser/Kraftfile
@@ -4,6 +4,8 @@ name: vnc-browser
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/wrapper.sh" ]

--- a/opentelemetry-collector/Kraftfile
+++ b/opentelemetry-collector/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/otelcontribcol", "--config", "/etc/otel/config.yaml"]

--- a/phoenix-postgres/myapp/Kraftfile
+++ b/phoenix-postgres/myapp/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/app/bin/server" ]

--- a/phoenix-postgres/postgres/Kraftfile
+++ b/phoenix-postgres/postgres/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "docker-entrypoint.sh", "postgres", "-c", "shared_preload_libraries='pg_ukc_scaletozero'" ]

--- a/postgres/Kraftfile
+++ b/postgres/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh", "postgres", "-c", "shared_preload_libraries='pg_ukc_scaletozero'"]

--- a/python-playwright-chromium/Kraftfile
+++ b/python-playwright-chromium/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "fastapi", "run", "main.py", "--port", "8080"]

--- a/ruby3.2-rails/Kraftfile
+++ b/ruby3.2-rails/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/ruby", "/app/bin/rails", "server", "-b", "0.0.0.0"]

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -145,7 +145,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/ruby", "/app/bin/rails", "server", "-b", "0.0.0.0"]`: Use `/usr/bin/ruby /app/bin/rails server -b 0.0.0.0` as the starting command of the instance.
 

--- a/skipper0.18/Kraftfile
+++ b/skipper0.18/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/skipper", "-address", ":9090", "-routes-file", "/etc/skipper/example.eskip"]

--- a/spin-wagi-http/Kraftfile
+++ b/spin-wagi-http/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/spin", "up", "--from", "/app/spin.toml", "--listen", "0.0.0.0:3000"]

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -127,7 +127,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/spin", "up", "--from", "/app/spin.toml", "--listen", "0.0.0.0:3000"]`: Use `spin` as the command to start the app, with the given parameters.
 

--- a/traefik/Kraftfile
+++ b/traefik/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/traefik", "-configFile", "/etc/traefik/default.toml"]

--- a/tyk/Kraftfile
+++ b/tyk/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/tyk", "start", "--conf", "/etc/tyk.conf"]

--- a/visual-studio-code-server/Kraftfile
+++ b/visual-studio-code-server/Kraftfile
@@ -2,6 +2,8 @@ spec: v0.6
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/app/code-server/bin/code-server", "--host", "0.0.0.0", "--port", "8443", "--auth", "password" ]

--- a/vsftpd/Kraftfile
+++ b/vsftpd/Kraftfile
@@ -4,6 +4,8 @@ name: vsftpd
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/wrapper.sh" ]

--- a/wazero-import-go/Kraftfile
+++ b/wazero-import-go/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/age-calculator", "2000"]

--- a/wordpress-all-in-one/Kraftfile
+++ b/wordpress-all-in-one/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 3000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh"]

--- a/wordpress-compose/mariadb/Kraftfile
+++ b/wordpress-compose/mariadb/Kraftfile
@@ -4,6 +4,8 @@ name: mariadb
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh"]

--- a/wordpress-compose/wordpress/Kraftfile
+++ b/wordpress-compose/wordpress/Kraftfile
@@ -4,6 +4,8 @@ name: wordpress-nginx
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/wrapper.sh" ]


### PR DESCRIPTION
The chromium-cdp Kraftfile refers to ./initrd which is an EROFS archive which is built by deploy.sh,
so that example did not need to be changed.