### PR TITLE
chore: Replace kraft cloud tunnel with socat

### DIFF
--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -87,13 +87,11 @@ timestamps:
 
 In this case, the instance name is `mariadb-w2g2z` which is different for each run.
 
-To test the deployment, first forward the port with the `kraft cloud tunnel` command.
+To test the deployment, first forward the port with the `socat` command.
 
 ```bash
-kraft cloud tunnel 3306:mariadb-w2g2z:3306
+socat TCP-LISTEN:3306,reuseaddr,fork OPENSSL:twilight-sun-82lt4ddk.fra.unikraft.app:3306,verify=0
 ```
-
-The `kraft cloud tunnel` command is only supported by the legacy CLI.
 
 You can now, on a separate console, use the `mysql` command line tool to test that the set up works:
 
@@ -114,12 +112,13 @@ count(*)
 6
 ```
 
-To disconnect, kill the `tunnel` command using `Ctrl+c`.
+To disconnect, kill the `socat` command using `Ctrl+c`.
 
 > **Note:**
-> This guide uses `kraft cloud tunnel` only when a service doesn't support TLS and isn't HTTP-based (TLS/SNI determines the correct instance to send traffic to).
-> Also note that the `tunnel` command isn't needed when connecting via an instance's private IP/FQDN.
-> For example when the MariaDB instance serves as a database server to another instance that acts as a frontend and which **does** support TLS.
+> This guide uses `socat` for port forwarding only when a service doesn't support TLS and isn't HTTP-based (TLS/SNI determines the correct instance to send traffic to).
+> Also note that port forwarding isn't needed when connecting via an instance's private IP/FQDN.
+> For example, when a MariaDB instance serves as a database server to
+> another instance that acts as a frontend and which **does** support TLS.
 
 You can list information about the instance by running:
 

--- a/memcached1.6/Dockerfile
+++ b/memcached1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM memcached:1.6.23-bookworm as build
+FROM memcached:1.6.23-bookworm AS build
 
 FROM scratch
 

--- a/memcached1.6/README.md
+++ b/memcached1.6/README.md
@@ -89,21 +89,22 @@ timestamps:
 
 In this case, the instance name is `memcached16-arkv7` which is different for each run.
 
-To test the deployment, first forward the port with the `kraft cloud tunnel` command:
+To test the deployment, first forward the port with the `socat` command:
 
 ```bash
-kraft cloud tunnel 11211:memcached16-arkv7:11211
+socat TCP-LISTEN:11211,reuseaddr,fork OPENSSL:weathered-smoke-hehsdinv.fra.unikraft.app:11211,verify=0
 ```
-
-The `kraft cloud tunnel` command is only supported by the legacy CLI.
 
 Now, on a separate console, run the following commands to test that it works (you should see output when incrementing):
 
 ```console
 telnet 127.0.0.1 11211
+
 set test 0 0 1
 0
+
 incr test 1
+
 incr test 1
 ```
 
@@ -114,12 +115,13 @@ Ctrl + ]
 Ctrl + C
 ```
 
-To disconnect, kill the `tunnel` command with ctrl-C.
+To disconnect, kill the `socat` command with ctrl-C.
 
 > **Note:**
-> This guide uses `kraft cloud tunnel` only when a service doesn't support TLS and isn't HTTP-based (TLS/SNI determines the correct instance to send traffic to).
-> Also note that the `tunnel` command isn't needed when connecting via an instance's private IP/FQDN.
-> For example when a Memcached instance serves as a cache server to another instance that acts as a frontend and which **does** support TLS.
+> This guide uses `socat` for port forwarding only when a service doesn't support TLS and isn't HTTP-based (TLS/SNI determines the correct instance to send traffic to).
+> Also note that port forwarding isn't needed when connecting via an instance's private IP/FQDN.
+> For example, when a Memcached instance serves as a cache server to
+> another instance that acts as a frontend and which **does** support TLS.
 
 You can list information about the instance by running:
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -120,8 +120,8 @@ Use SQL and `psql` commands for your work.
 > You can see this in action by running `SELECT pg_sleep(10);` and verifying that the instance keeps on running.
 
 > **Note:**
-> If you'd like to use a port other than `5432/tls` you'll need to use the `kraft cloud tunnel` command to connect to PostgreSQL.
-> See [the tunneling guide](https://unikraft.com/docs/cli/tunnel) for more information.
+> If you'd like to use a port other than `5432/tls` you'll need to use the `socat` command to connect to PostgreSQL.
+> See the [MariaDB](https://github.com/unikraft-cloud/examples/tree/main/mariadb) example for a guide on how to use it.
 > Additionally, you need to explicitly disable scale-to-zero by either changing the label in the `Kraftfile` or use `--scale-to-zero off` in the deploy command.
 
 You can list information about the instance by running:


### PR DESCRIPTION
Replaced remaining uses of `kraft cloud tunnel` with socat