### PR TITLE
chore(github-webhook-node): Build rootfs from scratch layer

### DIFF
--- a/github-webhook-node/Dockerfile
+++ b/github-webhook-node/Dockerfile
@@ -1,7 +1,18 @@
-FROM node:24-alpine
+FROM node:24-alpine AS build
 
 WORKDIR /app
 
 COPY server.js package*.json ./
 
 RUN npm install --omit=dev
+
+FROM scratch
+
+COPY --from=build /usr/local/bin/node /usr/local/bin/node
+
+COPY --from=build /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+
+COPY --from=build /app/node_modules /app/node_modules
+COPY --from=build /app/server.js /app/server.js


### PR DESCRIPTION
This reduces the rootfs size by not including unnecessary components from the alpine image

Closes: FIELD-319