### PR TITLE
feat(examples and workflows): Add prometheus-3

### DIFF
--- a/.github/workflows/example-prometheus-3-stable.yaml
+++ b/.github/workflows/example-prometheus-3-stable.yaml
@@ -1,0 +1,78 @@
+name: examples/prometheus-3 (stable)
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/example-prometheus-3-stable.yaml'
+    - 'prometheus-3/**'
+    - '!prometheus-3/README.md'
+
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches: [ main ]
+    paths:
+    - '.github/workflows/example-prometheus-3-stable.yaml'
+    - 'prometheus-3/**'
+    - '!prometheus-3/README.md'
+
+  schedule:
+  - cron: '0 15 * * 1-5'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STABLE }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      id: test
+      uses: unikraft/kraftkit@staging
+      with:
+        run: |
+          set -xe;
+
+          cd prometheus-3;
+
+          kraft cloud deploy \
+            --no-start \
+            --name prometheus-3-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-testing/base-compat:latest \
+            --subdomain prometheus-3-${GITHUB_RUN_ID} \
+            -p 443:9090 \
+            -M 2048 \
+            .;
+
+          kraft cloud vm start -w 5s prometheus-3-${GITHUB_RUN_ID};
+          sleep 5;
+
+          curl -Lv --fail-with-body --max-time 10 https://prometheus-3-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STABLE }}.unikraft.app
+
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+
+          kraft cloud vm stop prometheus-3-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs prometheus-3-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm prometheus-3-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/prometheus-3-${GITHUB_RUN_ID} || true;

--- a/.github/workflows/example-prometheus-3-staging.yaml
+++ b/.github/workflows/example-prometheus-3-staging.yaml
@@ -1,0 +1,78 @@
+name: examples/prometheus-3 (staging)
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: [ main ]
+    paths:
+    - .github/workflows/example-prometheus-3-staging.yaml
+    - prometheus-3/**
+    - '!prometheus-3/README.md'
+
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches: [ main ]
+    paths:
+    - .github/workflows/example-prometheus-3-staging.yaml
+    - prometheus-3/**
+    - '!prometheus-3/README.md'
+
+  schedule:
+  - cron: '0 15 * * 1-5'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UKC_METRO: "https://api.${{ vars.UKC_METRO_STAGING }}.unikraft.cloud/v1"
+  UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+  KRAFTKIT_NO_CHECK_UPDATES: true
+  KRAFTKIT_LOG_LEVEL: debug
+
+jobs:
+  integration:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test
+      id: test
+      uses: unikraft/kraftkit@staging
+      with:
+        run: |
+          set -xe;
+
+          cd prometheus-3;
+
+          kraft cloud deploy \
+            --no-start \
+            --name prometheus-3-${GITHUB_RUN_ID} \
+            --runtime index.unikraft.io/official-staging/base-compat:latest \
+            --subdomain prometheus-3-${GITHUB_RUN_ID} \
+            -p 443:9090 \
+            -M 2048 \
+            .;
+
+          kraft cloud vm start -w 5s prometheus-3-${GITHUB_RUN_ID};
+          sleep 5;
+
+          curl -Lv --fail-with-body --max-time 10 https://prometheus-3-${GITHUB_RUN_ID}.${{ vars.UKC_METRO_STAGING }}.unikraft.app
+
+    - name: Cleanup
+      uses: unikraft/kraftkit@staging
+      if: always()
+      with:
+        run: |
+          set -xe;
+
+          kraft cloud vm stop prometheus-3-${GITHUB_RUN_ID} || true;
+          kraft cloud vm logs prometheus-3-${GITHUB_RUN_ID} || true;
+          kraft cloud vm rm prometheus-3-${GITHUB_RUN_ID} || true;
+          kraft cloud img rm index.unikraft.io/test/prometheus-3-${GITHUB_RUN_ID} || true;

--- a/basic-ops/Kraftfile
+++ b/basic-ops/Kraftfile
@@ -4,6 +4,8 @@ name: httpserver-c
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/caddy2.7-go1.21/Kraftfile
+++ b/caddy2.7-go1.21/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/debian-ssh/Kraftfile
+++ b/debian-ssh/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh"]

--- a/dragonflydb/Kraftfile
+++ b/dragonflydb/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh"]

--- a/duckdb-go1.21/Kraftfile
+++ b/duckdb-go1.21/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/feature-change-instance-cmd/Kraftfile
+++ b/feature-change-instance-cmd/Kraftfile
@@ -4,6 +4,8 @@ name: httpserver-c
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/github-webhook-node/Kraftfile
+++ b/github-webhook-node/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "node", "/app/server.js" ]

--- a/grafana/Kraftfile
+++ b/grafana/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/share/grafana/bin/grafana", "server", "-homepath", "/usr/share/grafana/"]

--- a/haproxy/Kraftfile
+++ b/haproxy/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/haproxy", "-f", "/etc/haproxy/haproxy.conf"]

--- a/httpserver-boost1.74-gpp13.2/Kraftfile
+++ b/httpserver-boost1.74-gpp13.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/httpserver-boost1.74-gpp13.2/README.md
+++ b/httpserver-boost1.74-gpp13.2/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base`: The Unikraft runtime kernel to use is its base one.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/http_server"]`: Use `/http_server` as the starting command of the instance.
 

--- a/httpserver-bun/Kraftfile
+++ b/httpserver-bun/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/bun", "run", "/usr/src/server.ts"]

--- a/httpserver-bun/README.md
+++ b/httpserver-bun/README.md
@@ -115,7 +115,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/bun", "run", "/usr/src/server.ts"]`: Use `/usr/bin/bun run /usr/src/server.ts` as the starting command of the instance.
 

--- a/httpserver-c-debug/Kraftfile
+++ b/httpserver-c-debug/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh"]

--- a/httpserver-dotnet10.0/Kraftfile
+++ b/httpserver-dotnet10.0/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/app/src"]

--- a/httpserver-dotnet10.0/README.md
+++ b/httpserver-dotnet10.0/README.md
@@ -115,7 +115,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd:`: Use as the starting command of the instance.
 

--- a/httpserver-elixir1.16/Kraftfile
+++ b/httpserver-elixir1.16/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 3000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "_build/dev/rel/server/bin/server", "start"]

--- a/httpserver-erlang26.2/Kraftfile
+++ b/httpserver-erlang26.2/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/erl", "-noshell", "-s", "http_server"]

--- a/httpserver-expressjs4.18-node21/Kraftfile
+++ b/httpserver-expressjs4.18-node21/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-expressjs4.18-node21/README.md
+++ b/httpserver-expressjs4.18-node21/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/node", "/usr/src/server.js"]`: Use `/usr/bin/node /usr/src/server.js` as the starting command of the instance.
 

--- a/httpserver-flask-redis/Kraftfile
+++ b/httpserver-flask-redis/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/app/app.py"]

--- a/httpserver-gcc13.2/Kraftfile
+++ b/httpserver-gcc13.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/httpserver-go1.21/Kraftfile
+++ b/httpserver-go1.21/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-go1.22-redis/Kraftfile
+++ b/httpserver-go1.22-redis/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-gpp13.2/Kraftfile
+++ b/httpserver-gpp13.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/http_server"]

--- a/httpserver-gpp13.2/README.md
+++ b/httpserver-gpp13.2/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base`: The Unikraft runtime kernel to use is its base one.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/http_server"]`: Use `/http_server` as the starting command of the instance.
 

--- a/httpserver-java17-spring-petclinic/Kraftfile
+++ b/httpserver-java17-spring-petclinic/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/spring-petclinic-3.3.0-SNAPSHOT.jar"]
 

--- a/httpserver-java17-springboot3.5.x/Kraftfile
+++ b/httpserver-java17-springboot3.5.x/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/demo-0.0.1-SNAPSHOT.jar"]
 

--- a/httpserver-java17-springboot3.5.x/README.md
+++ b/httpserver-java17-springboot3.5.x/README.md
@@ -99,7 +99,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/lib/jvm/java-17-openjdk-amd64/bin/java", "-jar", "/usr/src/demo-0.0.1-SNAPSHOT.jar"]`: Use as the starting command of the instance.
 

--- a/httpserver-java21/Kraftfile
+++ b/httpserver-java21/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 # Path updated from Java 17 to Java 21
 cmd: ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "-classpath", "/usr/src/", "SimpleHttpServer"]

--- a/httpserver-java21/README.md
+++ b/httpserver-java21/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/lib/jvm/java-21-openjdk-amd64/bin/java", "-classpath", "/usr/src/", "SimpleHttpServer"]`: Use the Java runtime to run `SimpleHttpServer` as the starting command of the instance.
 

--- a/httpserver-lua5.1/Kraftfile
+++ b/httpserver-lua5.1/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/lua", "/http_server.lua"]

--- a/httpserver-nginx-vite-vanilla/Kraftfile
+++ b/httpserver-nginx-vite-vanilla/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/httpserver-nginx-vite-vanilla/README.md
+++ b/httpserver-nginx-vite-vanilla/README.md
@@ -128,7 +128,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]`: Use nginx to serve the built static files as the starting command of the instance.
 

--- a/httpserver-node-express-puppeteer/Kraftfile
+++ b/httpserver-node-express-puppeteer/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/bin/www"]

--- a/httpserver-node-vite-ssr-vanilla/Kraftfile
+++ b/httpserver-node-vite-ssr-vanilla/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 2000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["node", "/app/server.js"]

--- a/httpserver-node-vite-vanilla/Kraftfile
+++ b/httpserver-node-vite-vanilla/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 2000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["npm", "run", "dev"]

--- a/httpserver-node21-nextjs/Kraftfile
+++ b/httpserver-node21-nextjs/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-node21-nextjs/README.md
+++ b/httpserver-node21-nextjs/README.md
@@ -117,7 +117,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: [["/usr/bin/node", "/usr/src/server.js"]]`: Use `/usr/bin/node /usr/src/server.js` as the starting command of the instance.
 

--- a/httpserver-node21-remix/Kraftfile
+++ b/httpserver-node21-remix/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-node21-solid-start/Kraftfile
+++ b/httpserver-node21-solid-start/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server/index.mjs"]

--- a/httpserver-node21-sveltekit/Kraftfile
+++ b/httpserver-node21-sveltekit/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/app/build/index.js"]

--- a/httpserver-node21-sveltekit/README.md
+++ b/httpserver-node21-sveltekit/README.md
@@ -161,7 +161,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: [["/usr/bin/node", "/app/build/index.js"]]`: Use `/usr/bin/node /app/build/index.js` as the starting command of the instance.
 

--- a/httpserver-node25/Kraftfile
+++ b/httpserver-node25/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-node25/README.md
+++ b/httpserver-node25/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/node", "/usr/src/server.js"]`: Use `/usr/bin/node /usr/src/server.js` as the starting command of the instance.
 

--- a/httpserver-perl5.42/Kraftfile
+++ b/httpserver-perl5.42/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/perl", "/usr/src/server.pl"]

--- a/httpserver-php8.2/Kraftfile
+++ b/httpserver-php8.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/php /usr/src/server.php"]

--- a/httpserver-prisma-expressjs4.19-node18/Kraftfile
+++ b/httpserver-prisma-expressjs4.19-node18/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/httpserver-python3.12-django5.0/Kraftfile
+++ b/httpserver-python3.12-django5.0/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/app/main.py"]

--- a/httpserver-python3.12-django5.0/README.md
+++ b/httpserver-python3.12-django5.0/README.md
@@ -138,7 +138,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/app/main.py"]`: Use this as the starting command of the instance.
 

--- a/httpserver-python3.12-fastapi-0.121.3/Kraftfile
+++ b/httpserver-python3.12-fastapi-0.121.3/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/httpserver-python3.12-fastapi-0.121.3/README.md
+++ b/httpserver-python3.12-fastapi-0.121.3/README.md
@@ -115,7 +115,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The Unikraft runtime kernel to use is the latest that provides a minimal Linux-compatible environment.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "-m", "uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "8080"]`: Use this as the starting command of the instance.
 

--- a/httpserver-python3.12-flask3.0-sqlite/Kraftfile
+++ b/httpserver-python3.12-flask3.0-sqlite/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/app/server.py"]

--- a/httpserver-python3.12-flask3.0-sqlite/README.md
+++ b/httpserver-python3.12-flask3.0-sqlite/README.md
@@ -134,7 +134,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/app/server.py"]`: Use `/usr/bin/python3 /app/server.py` as the starting command of the instance.
 

--- a/httpserver-python3.12-flask3.0/Kraftfile
+++ b/httpserver-python3.12-flask3.0/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/src/server.py"]

--- a/httpserver-python3.12-flask3.0/README.md
+++ b/httpserver-python3.12-flask3.0/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/src/server.py"]`: Use `/usr/bin/python3 /src/server.py` as the starting command of the instance.
 

--- a/httpserver-python3.12/Kraftfile
+++ b/httpserver-python3.12/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/python3", "/src/server.py"]

--- a/httpserver-python3.12/README.md
+++ b/httpserver-python3.12/README.md
@@ -116,7 +116,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/python3", "/src/server.py"]`: Use `/usr/bin/python3 /src/server.py` as the starting command of the instance.
 

--- a/httpserver-ruby3.2/Kraftfile
+++ b/httpserver-ruby3.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/ruby", "/src/server.rb"]

--- a/httpserver-rust-trunkrs-leptos/Kraftfile
+++ b/httpserver-rust-trunkrs-leptos/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/httpserver-rust1.75-tokio/Kraftfile
+++ b/httpserver-rust1.75-tokio/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-rust1.81-rocket0.5/Kraftfile
+++ b/httpserver-rust1.81-rocket0.5/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-rust1.87-actix-web4/Kraftfile
+++ b/httpserver-rust1.87-actix-web4/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/httpserver-rust1.91/Kraftfile
+++ b/httpserver-rust1.91/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/server"]

--- a/hugo0.122/Kraftfile
+++ b/hugo0.122/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/hugo", "server", "--bind=0.0.0.0", "--source", "/site"]

--- a/imaginary/Kraftfile
+++ b/imaginary/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/imaginary", "-p", "8080"]

--- a/mariadb/Kraftfile
+++ b/mariadb/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh"]

--- a/mcp-server-arxiv/Kraftfile
+++ b/mcp-server-arxiv/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/usr/local/bin/python", "/src/server.py" ]

--- a/mcp-server-simple/Kraftfile
+++ b/mcp-server-simple/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/usr/bin/python3", "/src/server.py" ]

--- a/memcached1.6/Kraftfile
+++ b/memcached1.6/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/memcached", "-u", "root"]

--- a/minio/Kraftfile
+++ b/minio/Kraftfile
@@ -7,7 +7,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [
   "/usr/bin/minio",

--- a/mongodb/Kraftfile
+++ b/mongodb/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/mongod", "--bind_ip_all", "--nounixsocket"]

--- a/nginx-flask-mongo/flask/Kraftfile
+++ b/nginx-flask-mongo/flask/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   # cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "python", "/app/server.py" ]

--- a/nginx-flask-mongo/nginx/Kraftfile
+++ b/nginx-flask-mongo/nginx/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "nginx" ]

--- a/nginx/Kraftfile
+++ b/nginx/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/node-playwright-chromium/Kraftfile
+++ b/node-playwright-chromium/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/server.js"]

--- a/node-playwright-firefox/Kraftfile
+++ b/node-playwright-firefox/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/server.js"]

--- a/node-playwright-firefox/redis7.2/Kraftfile
+++ b/node-playwright-firefox/redis7.2/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/redis-server", "/etc/redis/redis.conf"]

--- a/node-playwright-webkit/Kraftfile
+++ b/node-playwright-webkit/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "/usr/bin/node", "/app/server.js"]

--- a/node18-agario/Kraftfile
+++ b/node18-agario/Kraftfile
@@ -9,7 +9,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 2000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["node", "/usr/src/app/bin/server/server.js"]
 

--- a/node18-wingsio/Kraftfile
+++ b/node18-wingsio/Kraftfile
@@ -9,7 +9,9 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1500
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["node", "/usr/src/app/server.js"]
 

--- a/node21-websocket/Kraftfile
+++ b/node21-websocket/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/node", "/usr/src/server.js"]

--- a/node24-karaoke/README.md
+++ b/node24-karaoke/README.md
@@ -126,7 +126,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The kernel to use.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/entrypoint.sh"]`: Use `/entrypoint.sh` as the starting command of the instance.
 

--- a/novnc-browser/Kraftfile
+++ b/novnc-browser/Kraftfile
@@ -4,6 +4,8 @@ name: vnc-browser
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/wrapper.sh" ]

--- a/opentelemetry-collector/Kraftfile
+++ b/opentelemetry-collector/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/otelcontribcol", "--config", "/etc/otel/config.yaml"]

--- a/phoenix-postgres/myapp/Kraftfile
+++ b/phoenix-postgres/myapp/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/app/bin/server" ]

--- a/phoenix-postgres/postgres/Kraftfile
+++ b/phoenix-postgres/postgres/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "docker-entrypoint.sh", "postgres", "-c", "shared_preload_libraries='pg_ukc_scaletozero'" ]

--- a/postgres/Kraftfile
+++ b/postgres/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh", "postgres", "-c", "shared_preload_libraries='pg_ukc_scaletozero'"]

--- a/prometheus-3/Dockerfile
+++ b/prometheus-3/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:latest
+
+RUN apk add --no-cache prometheus && \
+    mkdir -p /prometheus
+
+COPY prometheus.yml /etc/prometheus/prometheus.yml
+
+EXPOSE 9090
+
+ENTRYPOINT ["/usr/bin/prometheus", "--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"]

--- a/prometheus-3/Kraftfile
+++ b/prometheus-3/Kraftfile
@@ -1,0 +1,9 @@
+spec: v0.7
+
+runtime: base-compat:latest
+
+rootfs:
+  source: ./Dockerfile
+  format: erofs
+
+cmd: ["/usr/bin/prometheus", "--config.file=/etc/prometheus/prometheus.yml", "--storage.tsdb.path=/prometheus"]

--- a/prometheus-3/README.md
+++ b/prometheus-3/README.md
@@ -1,0 +1,193 @@
+# Prometheus3
+
+This guide shows you how to use [Prometheus](https://prometheus.io/), an open source systems monitoring and alerting toolkit.
+
+To run it, follow these steps:
+
+1. Install the CLI.
+   Use the [unikraft CLI](https://unikraft.com/docs/cli/unikraft) or the legacy [kraft CLI](https://unikraft.org/docs/cli/install).
+   You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
+   Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
+
+2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/prometheus/` directory:
+
+```bash
+git clone https://github.com/unikraft-cloud/examples
+cd examples/prometheus/
+```
+
+Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
+This guide uses `fra` (Frankfurt, 🇩🇪):
+
+```bash title="unikraft"
+unikraft login
+```
+
+or
+
+```bash title="kraft"
+# Set Unikraft Cloud access token
+export UKC_TOKEN=token
+# Set metro to Frankfurt, DE
+export UKC_METRO=fra
+```
+
+When done, invoke the following command to deploy this app on Unikraft Cloud:
+
+```bash title="unikraft"
+unikraft build . --output <my-org>/prometheus:latest
+unikraft run --metro fra -p 443:9090/tls+http -m 2G --image <my-org>/prometheus:latest
+```
+
+or
+
+```bash title="kraft"
+kraft cloud deploy -p 443:9090 -M 2Gi .
+```
+
+The output shows the instance address and other details:
+
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: prometheus-xk7pq
+ ├───────── uuid: 7f3a2c91-df14-4b08-ae31-c2e085f30a11
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://bright-rain-7xk2mn4p.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/prometheus@sha256:9bcd3451aa72b4ef8a8c1f20302bb84f1570443a93ab9698c1f1e02602bb1234
+ ├─────── memory: 2048 MiB
+ ├────── service: bright-rain-7xk2mn4p
+ ├─ private fqdn: prometheus-xk7pq.internal
+ └─── private ip: 10.0.3.1
+```
+
+or
+
+```ansi title="unikraft"
+metro:        fra
+name:         prometheus-xk7pq
+uuid:         7f3a2c91-df14-4b08-ae31-c2e085f30a11
+state:        starting
+image:        <my-org>/prometheus
+resources:
+  memory:     2048MiB
+  vcpus:      1
+service:
+  uuid:       12bc9041-c23d-4f8a-bb12-8acde3512f7c
+  name:       bright-rain-7xk2mn4p
+  domains:
+  - fqdn:     bright-rain-7xk2mn4p.fra.unikraft.app
+networks:
+- uuid:       a3ccf7b2-82e4-6693-14b3-2f53663g5eae
+  private-ip: 10.0.3.1
+  mac:        12:b0:c0:f1:06:cd
+timestamps:
+  created:    just now
+```
+
+In this case, the instance name is `prometheus-xk7pq` and the address is `https://bright-rain-7xk2mn4p.fra.unikraft.app`.
+They're different for each run.
+
+Use `curl` to query the Prometheus metrics endpoint on the Unikraft Cloud instance:
+
+```bash
+curl https://bright-rain-7xk2mn4p.fra.unikraft.app/metrics
+```
+
+You can also open the Prometheus web UI in your browser:
+
+```
+https://bright-rain-7xk2mn4p.fra.unikraft.app
+```
+
+You can list information about the instance by running:
+
+```bash title="unikraft"
+unikraft instances list
+```
+
+```ansi title="unikraft"
+METRO  NAME              STATE    IMAGE                ARGS  MEMORY  VCPUS  FQDN                                   CREATED
+fra    prometheus-xk7pq  running  <my-org>/prometheus        2.0GiB  1      bright-rain-7xk2mn4p.fra.unikraft.app  2 minutes ago
+```
+
+or
+
+```bash title="kraft"
+kraft cloud instance list
+```
+
+```ansi title="kraft"
+NAME              FQDN                                   STATE    STATUS         IMAGE                                             MEMORY   VCPUS  ARGS  BOOT TIME
+prometheus-xk7pq  bright-rain-7xk2mn4p.fra.unikraft.app  running  2 minutes ago  oci://unikraft.io/<my-org>/prometheus@sha256:...  2.0 GiB  1            412.53 ms
+```
+
+When done, you can remove the instance:
+
+```bash title="unikraft"
+unikraft instances delete prometheus-xk7pq
+```
+
+or
+
+```bash title="kraft"
+kraft cloud instance remove prometheus-xk7pq
+```
+
+## Customize your app
+
+To customize the app, update the files in the repository, listed below:
+
+* `prometheus.yml`: the Prometheus configuration file
+* `Dockerfile`: the Docker-specified app filesystem
+
+Lines in the `Dockerfile` have the following roles:
+
+* `FROM alpine:latest`: Use the latest Alpine Linux image as the base. 
+  *(Note: The directory for this example is explicitly named `prometheus-3` because `alpine:latest` currently provides the 3.x series of Prometheus. This version pinning ensures the `prometheus.yml` configuration remains compatible and future-proofs the example against breaking changes in future major releases).*
+
+* `RUN apk add --no-cache prometheus`: Install Prometheus via the Alpine package manager.
+
+* `EXPOSE 9090`: Expose port `9090`, the default Prometheus HTTP port.
+
+* `ENTRYPOINT ["/usr/bin/prometheus", ...]`: Start Prometheus with the provided configuration file and storage path.
+
+Key sections in `prometheus.yml` have the following roles:
+
+* `global`: Sets global defaults for `scrape_interval`, `scrape_timeout`, and `evaluation_interval`, as well as `external_labels` attached to all time series and alerts.
+
+* `rule_files`: Specifies paths to alerting and recording rule files to load.
+
+* `alerting`: Configures the Alertmanager instances Prometheus should send alerts to.
+
+* `scrape_configs`: Defines the targets Prometheus scrapes for metrics. The default configuration includes:
+  - `prometheus`: Prometheus scrapes itself at `localhost:9090`.
+  - `node`: Scrapes a Node Exporter instance at `node-exporter:9100` for host-level metrics.
+  - `my-app`: An example job showing how to scrape a custom application.
+
+The following options are available for customizing the app:
+
+* To add or remove scrape targets, edit the `scrape_configs` section in `prometheus.yml`.
+
+* To adjust how frequently metrics are collected, change the `scrape_interval` and `evaluation_interval` values under `global`.
+
+* To load alerting or recording rules, place rule files under a `rules/` directory and reference them in the `rule_files` section.
+
+* More extensive changes may require extending the `Dockerfile` ([see `Dockerfile` syntax reference](https://docs.docker.com/engine/reference/builder/)).
+
+## Learn more
+
+Use the `--help` option for detailed information on using Unikraft Cloud:
+
+```bash title="unikraft"
+unikraft --help
+```
+
+or
+
+```bash title="kraft"
+kraft cloud --help
+```
+
+Or visit the [CLI Reference](https://unikraft.com/docs/cli/unikraft) or the [legacy CLI Reference](https://unikraft.com/docs/cli/kraft/overview).

--- a/prometheus-3/prometheus.yml
+++ b/prometheus-3/prometheus.yml
@@ -1,0 +1,56 @@
+# prometheus.yml — Basic Prometheus Configuration
+
+global:
+# How often to scrape targets
+scrape_interval: 15s
+
+# How long before a scrape request times out
+scrape_timeout: 10s
+
+# How often to evaluate alerting/recording rules
+evaluation_interval: 15s
+
+# Labels added to all time series and alerts sent to external systems
+external_labels:
+env: production
+region: us-east-1
+
+# Load rule files (alerting and recording rules)
+rule_files:
+- "rules/*.yml"
+
+# Alertmanager configuration
+alerting:
+alertmanagers:
+- static_configs:
+- targets:
+- "alertmanager:9093"
+
+# Scrape configurations
+scrape_configs:
+
+# Prometheus scrapes itself
+- job_name: "prometheus"
+static_configs:
+- targets:
+- "localhost:9090"
+
+# Node Exporter — host-level metrics (CPU, memory, disk, network)
+- job_name: "node"
+static_configs:
+- targets:
+- "node-exporter:9100"
+# Optional: override global scrape interval for this job
+scrape_interval: 30s
+
+# Example: scraping a custom application
+- job_name: "my-app"
+metrics_path: /metrics # default, shown for clarity
+scheme: http # default, use https if TLS is enabled
+static_configs:
+- targets:
+- "my-app-1:8080"
+- "my-app-2:8080"
+labels:
+service: my-app
+team: backend

--- a/python-playwright-chromium/Kraftfile
+++ b/python-playwright-chromium/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/wrapper.sh", "fastapi", "run", "main.py", "--port", "8080"]

--- a/ruby3.2-rails/Kraftfile
+++ b/ruby3.2-rails/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/ruby", "/app/bin/rails", "server", "-b", "0.0.0.0"]

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -145,7 +145,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/ruby", "/app/bin/rails", "server", "-b", "0.0.0.0"]`: Use `/usr/bin/ruby /app/bin/rails server -b 0.0.0.0` as the starting command of the instance.
 

--- a/skipper0.18/Kraftfile
+++ b/skipper0.18/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/skipper", "-address", ":9090", "-routes-file", "/etc/skipper/example.eskip"]

--- a/spin-wagi-http/Kraftfile
+++ b/spin-wagi-http/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/spin", "up", "--from", "/app/spin.toml", "--listen", "0.0.0.0:3000"]

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -127,7 +127,9 @@ Lines in the `Kraftfile` have the following roles:
 
 * `runtime: base-compat:latest`: The runtime kernel to use is the base compatibility kernel.
 
-* `rootfs: ./Dockerfile`: Build the app root filesystem using the `Dockerfile`.
+* `rootfs`: Build the app root filesystem.
+  `source: ./Dockerfile` means the filesystem is built using the `Dockerfile`.
+  `type: erofs` means the filesystem type is [EROFS](https://erofs.docs.kernel.org/).
 
 * `cmd: ["/usr/bin/spin", "up", "--from", "/app/spin.toml", "--listen", "0.0.0.0:3000"]`: Use `spin` as the command to start the app, with the given parameters.
 

--- a/traefik/Kraftfile
+++ b/traefik/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/traefik", "-configFile", "/etc/traefik/default.toml"]

--- a/tyk/Kraftfile
+++ b/tyk/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/bin/tyk", "start", "--conf", "/etc/tyk.conf"]

--- a/visual-studio-code-server/Kraftfile
+++ b/visual-studio-code-server/Kraftfile
@@ -2,6 +2,8 @@ spec: v0.6
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/app/code-server/bin/code-server", "--host", "0.0.0.0", "--port", "8443", "--auth", "password" ]

--- a/vsftpd/Kraftfile
+++ b/vsftpd/Kraftfile
@@ -4,6 +4,8 @@ name: vsftpd
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/wrapper.sh" ]

--- a/wazero-import-go/Kraftfile
+++ b/wazero-import-go/Kraftfile
@@ -7,6 +7,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "false"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 1000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/age-calculator", "2000"]

--- a/wordpress-all-in-one/Kraftfile
+++ b/wordpress-all-in-one/Kraftfile
@@ -9,6 +9,8 @@ labels:
   cloud.unikraft.v1.instances/scale_to_zero.stateful: "true"
   cloud.unikraft.v1.instances/scale_to_zero.cooldown_time_ms: 3000
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh"]

--- a/wordpress-compose/mariadb/Kraftfile
+++ b/wordpress-compose/mariadb/Kraftfile
@@ -4,6 +4,8 @@ name: mariadb
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: ["/usr/local/bin/wrapper.sh"]

--- a/wordpress-compose/wordpress/Kraftfile
+++ b/wordpress-compose/wordpress/Kraftfile
@@ -4,6 +4,8 @@ name: wordpress-nginx
 
 runtime: base-compat:latest
 
-rootfs: ./Dockerfile
+rootfs:
+  source: ./Dockerfile
+  type: erofs
 
 cmd: [ "/wrapper.sh" ]


### PR DESCRIPTION
The directory is explicitly named 'prometheus-3' rather than 'latest' to 
track the current 3.x package provided by Alpine Linux, future-proofing
the example against other rules when 4.x comes