### PR TITLE
fix: Clearer separation between unikraft and kraftkit instructions

### DIFF
--- a/build-environments/README.md
+++ b/build-environments/README.md
@@ -13,6 +13,10 @@ This pattern is useful for build and test environments where runtime code change
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, set up and use BuildKit directly, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/build-environments` directory:
 
 ```bash
@@ -23,12 +27,14 @@ cd examples/build-environments/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -41,12 +47,14 @@ export UKC_METRO=fra
 
 Package and push the base Go runtime image (see `server.go` for the runtime implementation):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/go-build-env:latest
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft pkg \
    --name index.unikraft.io/<my-org>/go-build-env:latest \
@@ -64,6 +72,7 @@ The server in [`server.go`](./server.go) loads `/rom/rom.go`, compiles it to `/r
 Create a short-lived instance from the base image (without ROM attached).
 The server writes to `/uk/libukp/template_instance` and turns the instance into a template before serving requests (see https://unikraft.com/docs/platform/instances#instance-templates):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft run --metro fra \
   --name go-build-env \
@@ -73,6 +82,7 @@ unikraft run --metro fra \
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance create \
   --start \
@@ -83,21 +93,7 @@ kraft cloud instance create \
 
 The output shows the instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: go-build-env
- ├───────── uuid: 650dbbe7-3949-4c93-88e7-6619a9216e0c
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├──────── image: oci://unikraft.io/<my-org>/go-build-env@sha256:1f57e9bb8702d031743acf43164b24cf182158c398f1eda8c5583208ccc9c300
- ├─────── memory: 512 MiB
- ├─ private fqdn: go-build-env.internal
- └─── private ip: 10.0.5.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         go-build-env
@@ -115,14 +111,32 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: go-build-env
+ ├───────── uuid: 650dbbe7-3949-4c93-88e7-6619a9216e0c
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├──────── image: oci://unikraft.io/<my-org>/go-build-env@sha256:1f57e9bb8702d031743acf43164b24cf182158c398f1eda8c5583208ccc9c300
+ ├─────── memory: 512 MiB
+ ├─ private fqdn: go-build-env.internal
+ └─── private ip: 10.0.5.4
+```
+
 If you are fast enough, you can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -130,6 +144,7 @@ kraft cloud instance list
 This instance is short-lived, since right before the server starts, it triggers a conversion into a template.
 To check the template is ready, run:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances templates list
 ```
@@ -141,6 +156,7 @@ fra    go-build-env  template  <my-org>/go-build-env        512MiB  1      2 min
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance template list
 ```
@@ -154,6 +170,7 @@ go-build-env  oci://unikraft.io/<my-org>/go-build-env@sha256:1f57e9bb8702d031743
 
 Each ROM contains a Go function implementation (see [`rom1/fs/rom.go`](./rom1/fs/rom.go) and [`rom2/fs/rom.go`](./rom2/fs/rom.go)).
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build rom1/ --output <my-org>/go-rom1:latest
 unikraft build rom2/ --output <my-org>/go-rom2:latest
@@ -161,6 +178,7 @@ unikraft build rom2/ --output <my-org>/go-rom2:latest
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft pkg \
    --rom ./fs \
@@ -184,6 +202,7 @@ kraft pkg \
 
 Create an instance with the first ROM:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft run --metro fra \
   --name go-build-env-rom1 \
@@ -195,6 +214,7 @@ unikraft run --metro fra \
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # kraft does not support creating instances with attached ROMs, but you can use the API directly
 curl -X POST "$UKC_METRO/instances" \
@@ -234,18 +254,21 @@ curl -X POST "$UKC_METRO/instances" \
 The instance will compile the ROM into a plugin on first start, which may take a few seconds.
 To check the progress, you can view the instance logs:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances logs go-build-env-rom1 -f
 ```
 
-or 
+or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance logs go-build-env-rom1 -f
 ```
 
 Create another instance with the second ROM:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft run --metro fra \
   --name go-build-env-rom2 \
@@ -257,6 +280,7 @@ unikraft run --metro fra \
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # kraft does not support creating instances with attached ROMs, but you can use the API directly
 curl -X POST "$UKC_METRO/instances" \
@@ -296,18 +320,21 @@ curl -X POST "$UKC_METRO/instances" \
 The instance will compile the ROM into a plugin on first start, which may take a few seconds.
 To check the progress, you can view the instance logs:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances logs go-build-env-rom2 -f
 ```
 
-or 
+or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance logs go-build-env-rom2 -f
 ```
 
 List the instances and note their FQDN values:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -320,6 +347,7 @@ fra    go-build-env-rom1  standby  <my-org>/go-build-env        512MiB  1      s
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -344,6 +372,7 @@ Auf Wiedersehen!
 
 ## Cleanup
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete go-build-env-rom1 go-build-env-rom2
 unikraft instances template delete go-build-env
@@ -351,6 +380,7 @@ unikraft instances template delete go-build-env
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove go-build-env-rom1 go-build-env-rom2
 kraft cloud instance template remove go-build-env
@@ -360,12 +390,14 @@ kraft cloud instance template remove go-build-env
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/caddy2.7-go1.21/README.md
+++ b/caddy2.7-go1.21/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/caddy2.7-go1.21/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/caddy2.7-go1.21/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/caddy27-go121:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:2015/http+tls -m 256M --image <my-org>/caddy27-go121:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:201
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:2015/http+tls -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: caddy27-go121-vhf4m
- ├───────── uuid: db624eff-4739-4500-873c-f7c58e4eefd7
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://frosty-sky-vz8kwsmb.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/caddy27-go121@sha256:25df97e3c43147c683f31dd062d0fa75122358b596de5804ca246c4e8613dd56
- ├─────── memory: 256 MiB
- ├────── service: frosty-sky-vz8kwsmb
- ├─ private fqdn: caddy27-go121-vhf4m.internal
- └─── private ip: 10.0.6.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         caddy27-go121-vhf4m
@@ -87,6 +79,25 @@ timestamps:
   created:    just now
 ```
 
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: caddy27-go121-vhf4m
+ ├───────── uuid: db624eff-4739-4500-873c-f7c58e4eefd7
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://frosty-sky-vz8kwsmb.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/caddy27-go121@sha256:25df97e3c43147c683f31dd062d0fa75122358b596de5804ca246c4e8613dd56
+ ├─────── memory: 256 MiB
+ ├────── service: frosty-sky-vz8kwsmb
+ ├─ private fqdn: caddy27-go121-vhf4m.internal
+ └─── private ip: 10.0.6.2
+```
+
 In this case, the instance name is `caddy27-go121-vhf4m` and the address is `https://frosty-sky-vz8kwsmb.fra.unikraft.app`.
 They're different for each run.
 
@@ -102,6 +113,7 @@ Hello World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -113,6 +125,7 @@ fra    caddy27-go121-vhf4m  running  <my-org>/caddy27-go121        256MiB  1    
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,12 +137,14 @@ caddy27-go121-vhf4m  frosty-sky-vz8kwsmb.fra.unikraft.app  running  1 minute ago
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete caddy27-go121-vhf4m
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove caddy27-go121-vhf4m
 ```
@@ -168,12 +183,14 @@ You can set a new webroot (different than `rootfs`), or a different internal por
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/chromium-cdp/README.md
+++ b/chromium-cdp/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/chromium-cdp/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/chromium-cdp/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -42,23 +48,7 @@ You can run the deploy script (which builds an erofs root filesystem and deploys
 
 The output shows the instance address and other details.
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: chromium-cdp-d0l6y
- ├───────── uuid: debe81b0-8418-4e01-b795-b3546e0e5aac
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://spring-dream-p5wxwwl0.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/chromium-cdp@sha256:9e22546a9234efbd586b3cc3ff2ab71d64b56e87b8af431a3dfffd4aff274cc3
- ├─────── memory: 4096 MiB
- ├────── service: spring-dream-p5wxwwl0
- ├─ private fqdn: chromium-cdp-d0l6y.internal
- └─── private ip: 10.0.4.141
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         chromium-cdp-d0l6y
@@ -81,6 +71,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: chromium-cdp-d0l6y
+ ├───────── uuid: debe81b0-8418-4e01-b795-b3546e0e5aac
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://spring-dream-p5wxwwl0.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/chromium-cdp@sha256:9e22546a9234efbd586b3cc3ff2ab71d64b56e87b8af431a3dfffd4aff274cc3
+ ├─────── memory: 4096 MiB
+ ├────── service: spring-dream-p5wxwwl0
+ ├─ private fqdn: chromium-cdp-d0l6y.internal
+ └─── private ip: 10.0.4.141
+```
+
 In this case, the instance name is `chromium-cdp-d0l6y` and the address is `https://spring-dream-p5wxwwl0.fra.unikraft.app`.
 They're different for each run.
 
@@ -89,6 +97,7 @@ You can use the Python-based implementation in the `test/` directory.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -100,6 +109,7 @@ fra    chromium-cdp-d0l6y  running  <my-org>/chromium-cdp        4096MiB  1     
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -111,12 +121,14 @@ chromium-cdp-d0l6y  spring-dream-p5wxwwl0.fra.unikraft.app  running  1 minute ag
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete chromium-cdp-d0l6y
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove chromium-cdp-d0l6y
 ```
@@ -130,12 +142,14 @@ kraft cloud instance remove chromium-cdp-d0l6y
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/debian-ssh/README.md
+++ b/debian-ssh/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/debian-ssh` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/debian-ssh/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/debian-ssh:latest
 unikraft run --scale-to-zero policy=off --metro fra -p 2222:2222/tls -m 1G -e PUBKEY="...." --image <my-org>/debian-ssh:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=off --metro fra -p 2222:2222/tls -m 1G -e PU
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero off -p 2222:2222/tls -M 1Gi -e PUBKEY="...." .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: debian-ssh-2uwg5
- ├───────── uuid: b3d158c5-fb52-4685-a76b-2497973308dc
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://nameless-cherry-sw2e9ul2.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/debian-ssh@sha256:2442b4d5e078e7bc9ccd887fac65623511551592315d341a219f34a2c6628949
- ├─────── memory: 1024 MiB
- ├────── service: nameless-cherry-sw2e9ul2
- ├─ private fqdn: debian-ssh-2uwg5.internal
- └─── private ip: 10.0.0.109
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         debian-ssh-2uwg5
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:1d:bd:54:f6
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: debian-ssh-2uwg5
+ ├───────── uuid: b3d158c5-fb52-4685-a76b-2497973308dc
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://nameless-cherry-sw2e9ul2.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/debian-ssh@sha256:2442b4d5e078e7bc9ccd887fac65623511551592315d341a219f34a2c6628949
+ ├─────── memory: 1024 MiB
+ ├────── service: nameless-cherry-sw2e9ul2
+ ├─ private fqdn: debian-ssh-2uwg5.internal
+ └─── private ip: 10.0.0.109
 ```
 
 In this case, the instance name is `debian-ssh-2uwg5` and the address is `nameless-cherry-sw2e9ul2.fra.unikraft.app`.
@@ -106,6 +116,7 @@ This is normal if you have set up tunnels to connect with SSH on `localhost`, so
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -117,6 +128,7 @@ fra    debian-ssh-2uwg5  running  <my-org>/debian-ssh        1.0GiB  1      name
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -128,12 +140,14 @@ debian-ssh-2uwg5  nameless-cherry-sw2e9ul2.fra.unikraft.app  running  since 5min
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete debian-ssh-2uwg5
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove debian-ssh-2uwg5
 ```
@@ -142,12 +156,14 @@ kraft cloud instance remove debian-ssh-2uwg5
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/dragonflydb/README.md
+++ b/dragonflydb/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/dragonflydb/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/dragonflydb/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/dragonflydb:latest
 unikraft run --scale-to-zero policy=off --metro fra -p 443:6379/http+tls -m 512M --image <my-org>/dragonflydb:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=off --metro fra -p 443:6379/http+tls -m 512M
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero off -p 443:6379/http+tls -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: dragonflydb-10zgk
- ├───────── uuid: 6282ef0c-2161-494c-a3f3-2d16055096c2
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://dry-moon-x6bgl6c0.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/dragonflydb@sha256:21e6d3ff1f86292e14266bcf5c6e73d3b7a86a0ec4102c66a0961373af743f19
- ├─────── memory: 512 MiB
- ├────── service: dry-moon-x6bgl6c0
- ├─ private fqdn: dragonflydb-10zgk.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         dragonflydb-10zgk
@@ -84,6 +76,24 @@ networks:
   mac:        12:b0:8f:c2:51:55
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: dragonflydb-10zgk
+ ├───────── uuid: 6282ef0c-2161-494c-a3f3-2d16055096c2
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://dry-moon-x6bgl6c0.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/dragonflydb@sha256:21e6d3ff1f86292e14266bcf5c6e73d3b7a86a0ec4102c66a0961373af743f19
+ ├─────── memory: 512 MiB
+ ├────── service: dry-moon-x6bgl6c0
+ ├─ private fqdn: dragonflydb-10zgk.internal
+ └─── private ip: 10.0.6.5
 ```
 
 In this case, the instance name is `dragonflydb-10zgk` and the address is `https://dry-moon-x6bgl6c0.fra.unikraft.app`.
@@ -124,6 +134,7 @@ document.querySelector('.left_panel').innerHTML = JsonToHTML(json_text1);
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -135,6 +146,7 @@ fra    dragonflydb-10zgk  running  <my-org>/dragonflydb        512MiB  1      dr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -146,12 +158,14 @@ dragonflydb-10zgk  dry-moon-x6bgl6c0.fra.unikraft.app  running  1 minute ago  oc
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete dragonflydb-10zgk
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove dragonflydb-10zgk
 ```
@@ -167,12 +181,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/duckdb-go1.21/README.md
+++ b/duckdb-go1.21/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/duckdb-go1.21/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/duckdb-go1.21/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/duckdb-go121:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/duckdb-go121:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: duckdb-go121-qfd8x
- ├───────── uuid: 90960d27-458b-4dd7-a037-2a9a3a47f095
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://autumn-gorilla-hg4h6sup.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/duckdb-go121@sha256:6999293f8694ac00beb6a1d639fab8f96f78c2e6ecb8ccb2311539908895a699
- ├─────── memory: 256 MiB
- ├────── service: autumn-gorilla-hg4h6sup
- ├─ private fqdn: duckdb-go121-qfd8x.internal
- └─── private ip: 10.0.6.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         duckdb-go121-qfd8x
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: duckdb-go121-qfd8x
+ ├───────── uuid: 90960d27-458b-4dd7-a037-2a9a3a47f095
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://autumn-gorilla-hg4h6sup.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/duckdb-go121@sha256:6999293f8694ac00beb6a1d639fab8f96f78c2e6ecb8ccb2311539908895a699
+ ├─────── memory: 256 MiB
+ ├────── service: autumn-gorilla-hg4h6sup
+ ├─ private fqdn: duckdb-go121-qfd8x.internal
+ └─── private ip: 10.0.6.2
+```
+
 In this case, the instance name is `duckdb-go121-qfd8x` and the address is `https://autumn-gorilla-hg4h6sup.fra.unikraft.app`.
 They're different for each run.
 
@@ -101,6 +111,7 @@ id: %d, name: %s 42 John
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -112,6 +123,7 @@ fra    duckdb-go121-qfd8x  running  <my-org>/duckdb-go121        256MiB  1      
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -123,12 +135,14 @@ duckdb-go121-qfd8x  autumn-gorilla-hg4h6sup.fra.unikraft.app  running  1 minute 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete duckdb-go121-qfd8x
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove duckdb-go121-qfd8x
 ```
@@ -157,12 +171,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/github-webhook-node/README.md
+++ b/github-webhook-node/README.md
@@ -11,6 +11,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/github-webhook-node/` directory:
 
 ```bash
@@ -21,12 +25,14 @@ cd examples/github-webhook-node/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -36,6 +42,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/github-webhook-node:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 1G -e GITHUB_WEBHOOK_SECRET=your_secret_here --image <my-org>/github-webhook-node:latest
@@ -43,31 +50,17 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 1Gi -e GITHUB_WEBHOOK_SECRET=your_secret_here .
 ```
 
 `GITHUB_WEBHOOK_SECRET` is the secret used to verify incoming webhook requests from GitHub.
 Set it to a string with high entropy.
+
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: github-webhook-node-bzq7u
- ├───────── uuid: 8a8634f1-fc78-4cc0-aa36-8f082d8a59f5
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://dry-cloud-uuw0qlb6.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/github-webhook-node@sha256:10974aac67ce6355148e21d91f918960bf0af29ad840fffeeb2fd01f8c905f66
- ├─────── memory: 1024 MiB
- ├────── service: dry-cloud-uuw0qlb6
- ├─ private fqdn: github-webhook-node-bzq7u.internal
- └─── private ip: 10.0.1.205
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         github-webhook-node-bzq7u
@@ -90,6 +83,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: github-webhook-node-bzq7u
+ ├───────── uuid: 8a8634f1-fc78-4cc0-aa36-8f082d8a59f5
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://dry-cloud-uuw0qlb6.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/github-webhook-node@sha256:10974aac67ce6355148e21d91f918960bf0af29ad840fffeeb2fd01f8c905f66
+ ├─────── memory: 1024 MiB
+ ├────── service: dry-cloud-uuw0qlb6
+ ├─ private fqdn: github-webhook-node-bzq7u.internal
+ └─── private ip: 10.0.1.205
+```
+
 In this case, the instance name is `github-webhook-node-bzq7u` and the address is `https://dry-cloud-uuw0qlb6.fra.unikraft.app`.
 They're different for each run.
 
@@ -108,12 +119,14 @@ When a request comes in, Unikraft Cloud automatically starts the instance.
 
 To see the incoming webhook events (you set up the [webhook in GitHub](#test-github-webhooks)), you can retrieve the logs of the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances logs github-webhook-node-bzq7u
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance logs github-webhook-node-bzq7u --follow
 ```
@@ -135,6 +148,7 @@ kraft cloud instance logs github-webhook-node-bzq7u --follow
 GitHub sends the `ping` event when you set up the webhook.
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -146,6 +160,7 @@ fra    github-webhook-node-bzq7u  standby  <my-org>/github-webhook-node        1
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -157,12 +172,14 @@ github-webhook-node-bzq7u  dry-cloud-uuw0qlb6.fra.unikraft.app  standby  standby
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete github-webhook-node-bzq7u
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove github-webhook-node-bzq7u
 ```
@@ -175,12 +192,14 @@ You should also set the content type to `application/json` and select the events
 Lastly, you should set the secret to verify that the requests come from GitHub and weren't tampered with.
 Now, once you make changes in the repository (that you are listening to), you should see the webhook events logged in the instance logs:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances logs github-webhook-node-bzq7u
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance logs github-webhook-node-bzq7u --follow
 ```
@@ -217,12 +236,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -9,6 +9,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/grafana/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/grafana/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/grafana:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 2G --image <my-org>/grafana:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 2Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: grafana-sikrv
- ├───────── uuid: 1d8f0b36-39ff-45a2-8baa-664640c60885
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://icy-sea-i6m5fwyk.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/grafana@sha256:484d6f98cdc321443188b8f2900035182dffdb45069f3cd087dcb6851ddff3bc
- ├─────── memory: 2048 MiB
- ├────── service: dawn-water-4jlnvgpy
- ├─ private fqdn: grafana-mgby4.internal
- └─── private ip: 10.0.6.6
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         grafana-sikrv
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: grafana-sikrv
+ ├───────── uuid: 1d8f0b36-39ff-45a2-8baa-664640c60885
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://icy-sea-i6m5fwyk.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/grafana@sha256:484d6f98cdc321443188b8f2900035182dffdb45069f3cd087dcb6851ddff3bc
+ ├─────── memory: 2048 MiB
+ ├────── service: dawn-water-4jlnvgpy
+ ├─ private fqdn: grafana-mgby4.internal
+ └─── private ip: 10.0.6.6
+```
+
 In this case, the instance name is `grafana-sikrv` and the address is `https://icy-sea-i6m5fwyk.fra.unikraft.app`.
 They're different for each run.
 
@@ -94,6 +104,7 @@ The default account/password are `admin/admin` (the system will prompt you to ch
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -105,6 +116,7 @@ fra    grafana-sikrv  running  <my-org>/grafana        2048MiB  1      icy-sea-i
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -116,12 +128,14 @@ grafana-sikrv  icy-sea-i6m5fwyk.fra.unikraft.app  running  11 minutes ago  oci:/
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete grafana-sikrv
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove grafana-sikrv
 ```
@@ -146,12 +160,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/haproxy/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/haproxy/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/haproxy:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8404/tls+http -m 256M --image <my-org>/haproxy:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:840
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8404/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: haproxy-rfx6z
- ├───────── uuid: 09bd081e-e082-4f73-8ba8-531123a39e2e
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://cool-paper-svzzr3qq.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/haproxy@sha256:32296847231c151506820ec4914c1d7416e5b7200caf07c1e40eaa3ea5033d21
- ├─────── memory: 256 MiB
- ├────── service: cool-paper-svzzr3qq
- ├─ private fqdn: haproxy-rfx6z.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         haproxy-rfx6z
@@ -87,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: haproxy-rfx6z
+ ├───────── uuid: 09bd081e-e082-4f73-8ba8-531123a39e2e
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://cool-paper-svzzr3qq.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/haproxy@sha256:32296847231c151506820ec4914c1d7416e5b7200caf07c1e40eaa3ea5033d21
+ ├─────── memory: 256 MiB
+ ├────── service: cool-paper-svzzr3qq
+ ├─ private fqdn: haproxy-rfx6z.internal
+ └─── private ip: 10.0.6.5
+```
+
 In this case, the instance name is `haproxy-rfx6z` and the address is `https://cool-paper-svzzr3qq.fra.unikraft.app`.
 They're different for each run.
 
@@ -94,6 +104,7 @@ To test, point your browser at the `/stats` endpoint (for example, `https://cool
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -105,6 +116,7 @@ fra    haproxy-rfx6z  running  <my-org>/haproxy        256MiB  1      cool-paper
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -116,12 +128,14 @@ haproxy-rfx6z  cool-paper-svzzr3qq.fra.unikraft.app  running  1 minute ago  oci:
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete haproxy-rfx6z
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove haproxy-rfx6z
 ```
@@ -137,12 +151,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-boost1.74-gpp13.2/README.md
+++ b/httpserver-boost1.74-gpp13.2/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [example repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-boost1.74-gpp13.2/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-boost1.74-gpp13.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-boost174-gpp132:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-boost174-gpp132:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-boost174-gpp132-rae7s
- ├───────── uuid: 5a9886fa-f8a3-4860-afcf-d5eb13fdc38d
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://red-snow-3bn7bzc8.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-boost174-gpp132@sha256:61cf86b89fed46351af53689e27189315e466576475f61c7240bf17644613489
- ├─────── memory: 256 MiB
- ├────── service: red-snow-3bn7bzc8
- ├─ private fqdn: httpserver-boost174-gpp132-rae7s.internal
- └─── private ip: 10.0.6.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-boost174-gpp132-rae7s
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-boost174-gpp132-rae7s
+ ├───────── uuid: 5a9886fa-f8a3-4860-afcf-d5eb13fdc38d
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://red-snow-3bn7bzc8.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-boost174-gpp132@sha256:61cf86b89fed46351af53689e27189315e466576475f61c7240bf17644613489
+ ├─────── memory: 256 MiB
+ ├────── service: red-snow-3bn7bzc8
+ ├─ private fqdn: httpserver-boost174-gpp132-rae7s.internal
+ └─── private ip: 10.0.6.4
+```
+
 In this case, the instance name is `httpserver-boost174-gpp132-rae7s` and the address is `https://red-snow-3bn7bzc8.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-boost174-gpp132-rae7s  running  <my-org>/httpserver-boost174-g
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-boost174-gpp132-rae7s  red-snow-3bn7bzc8.fra.unikraft.app  running  1
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-boost174-gpp132-rae7s
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-boost174-gpp132-rae7s
 ```
@@ -168,12 +182,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-bun/README.md
+++ b/httpserver-bun/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-bun` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-bun/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-bun:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-bun:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:300
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-bun-700mp
- ├───────── uuid: e467a880-075c-41e0-97ac-88e3e938523e
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://quiet-pond-ao44imcg.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-bun@sha256:dfcbee1efe0d8a1d43ab2dab70cf1cc5066bb1353aa1c528c745533d2cc33276
- ├─────── memory: 512 MiB
- ├────── service: quiet-pond-ao44imcg
- ├─ private fqdn: httpserver-bun-700mp.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-bun-700mp
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-bun-700mp
+ ├───────── uuid: e467a880-075c-41e0-97ac-88e3e938523e
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://quiet-pond-ao44imcg.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-bun@sha256:dfcbee1efe0d8a1d43ab2dab70cf1cc5066bb1353aa1c528c745533d2cc33276
+ ├─────── memory: 512 MiB
+ ├────── service: quiet-pond-ao44imcg
+ ├─ private fqdn: httpserver-bun-700mp.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-bun-700mp` and the address is `https://quiet-pond-ao44imcg.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-bun-700mp  running  <my-org>/httpserver-bun        512MiB  1  
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-bun-700mp  quiet-pond-ao44imcg.fra.unikraft.app  running  since 3mins
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-bun-700mp
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-bun-700mp
 ```
@@ -174,12 +188,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-c-debug/README.md
+++ b/httpserver-c-debug/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-c-debug` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-c-debug/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 For extensive debug information with `strace`, add the `USE_STRACE=1` environment variable to the deploy command:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-c-debug:latest
 unikraft run --scale-to-zero policy=off --metro fra -p 443:8080/tls+http -p 2222:2222/tls -e PUBKEY=.... -e USE_STRACE=1 -m 256M --image <my-org>/httpserver-c-debug:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=off --metro fra -p 443:8080/tls+http -p 2222
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero off -p 443:8080/tls+http -p 2222:2222/tls -M 256Mi -e PUBKEY="...." -e USE_STRACE=1 .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-c-debug-5pvem
- ├───────── uuid: 08629a94-e2b1-466e-abb9-15ce46411b66
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://patient-snow-zdzhdy8r.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-c-debug@sha256:b24b95e236c8eff69615dd4f5d257beed5ee4047fd98d1b6fb200f89c63fa54c
- ├─────── memory: 256 MiB
- ├────── service: patient-snow-zdzhdy8r
- ├─ private fqdn: httpserver-c-debug-5pvem.internal
- └─── private ip: 10.0.0.109
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-c-debug-5pvem
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:45:b3:18:b2
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-c-debug-5pvem
+ ├───────── uuid: 08629a94-e2b1-466e-abb9-15ce46411b66
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://patient-snow-zdzhdy8r.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-c-debug@sha256:b24b95e236c8eff69615dd4f5d257beed5ee4047fd98d1b6fb200f89c63fa54c
+ ├─────── memory: 256 MiB
+ ├────── service: patient-snow-zdzhdy8r
+ ├─ private fqdn: httpserver-c-debug-5pvem.internal
+ └─── private ip: 10.0.0.109
 ```
 
 In this case, the instance name is `httpserver-c-debug-5pvem` and the address is `patient-snow-zdzhdy8r.fra.unikraft.app`.
@@ -116,6 +126,7 @@ This is normal if you have set up tunnels to connect with SSH on `localhost`, so
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -127,6 +138,7 @@ fra    httpserver-c-debug-5pvem  running  <my-org>/httpserver-c-debug        256
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -138,12 +150,14 @@ httpserver-c-debug-5pvem  patient-snow-zdzhdy8r.fra.unikraft.app  running  since
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-c-debug-5pvem
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-c-debug-5pvem
 ```
@@ -152,12 +166,14 @@ kraft cloud instance remove httpserver-c-debug-5pvem
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-dotnet10.0/README.md
+++ b/httpserver-dotnet10.0/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-dotnet10.0/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-dotnet10.0/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-dotnet100:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-dotnet100:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-dotnet100-dsmkh
- ├───────── uuid: 25459494-cb43-4009-9d05-f0996de5b7e4
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://cold-fog-hl98aw6q.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-dotnet100@sha256:4fad7453995ae96b636696e9929ee0e7376bfbbd63ab9698c1f1e02602aa2575
- ├─────── memory: 512 MiB
- ├────── service: cold-fog-hl98aw6q
- ├─ private fqdn: httpserver-dotnet100-dsmkh.internal
- └─── private ip: 10.0.3.1
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-dotnet100-dsmkh
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-dotnet100-dsmkh
+ ├───────── uuid: 25459494-cb43-4009-9d05-f0996de5b7e4
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://cold-fog-hl98aw6q.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-dotnet100@sha256:4fad7453995ae96b636696e9929ee0e7376bfbbd63ab9698c1f1e02602aa2575
+ ├─────── memory: 512 MiB
+ ├────── service: cold-fog-hl98aw6q
+ ├─ private fqdn: httpserver-dotnet100-dsmkh.internal
+ └─── private ip: 10.0.3.1
+```
+
 In this case, the instance name is `httpserver-dotnet100-dsmkh` and the address is `https://cold-fog-hl98aw6q.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-dotnet100-dsmkh  running  <my-org>/httpserver-dotnet100       
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-dotnet100-dsmkh  cold-fog-hl98aw6q.fra.unikraft.app  running  2 minut
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-dotnet100-dsmkh
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-dotnet100-dsmkh
 ```
@@ -180,12 +194,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-elixir1.16/README.md
+++ b/httpserver-elixir1.16/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-elixir1.16/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-elixir1.16/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-elixir116:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=3000,stateful=true --metro fra -p 443:3000/tls+http -m 1G --image <my-org>/httpserver-elixir116:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=3000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 3s -p 443:3000/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-elixir116-qo9k3
- ├───────── uuid: e5fbf089-b000-4b2d-a827-44a1f5d28f24
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://small-water-tl8lr8am.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-elixir116@sha256:67f5df003758a1180932e931727f8cb7006bbbf6fdd84058e27fe05e4829bba0
- ├─────── memory: 1024 MiB
- ├────── service: small-water-tl8lr8am
- ├─ private fqdn: httpserver-elixir116-qo9k3.internal
- └─── private ip: 10.0.3.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-elixir116-qo9k3
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-elixir116-qo9k3
+ ├───────── uuid: e5fbf089-b000-4b2d-a827-44a1f5d28f24
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://small-water-tl8lr8am.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-elixir116@sha256:67f5df003758a1180932e931727f8cb7006bbbf6fdd84058e27fe05e4829bba0
+ ├─────── memory: 1024 MiB
+ ├────── service: small-water-tl8lr8am
+ ├─ private fqdn: httpserver-elixir116-qo9k3.internal
+ └─── private ip: 10.0.3.4
+```
+
 In this case, the instance name is `httpserver-elixir116-qo9k3` and the address is `https://small-water-tl8lr8am.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-elixir116-qo9k3  running  <my-org>/httpserver-elixir116       
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-elixir116-qo9k3  small-water-tl8lr8am.fra.unikraft.app  running  sinc
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-elixir116-qo9k3
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-elixir116-qo9k3
 ```
@@ -162,12 +176,14 @@ Then update it and deploy it on Unikraft Cloud using the above instructions.
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-erlang26.2/README.md
+++ b/httpserver-erlang26.2/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-erlang26.2/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-erlang26.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-erlang262:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-erlang262:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-erlang262-sw2bp
- ├───────── uuid: 1c4a8a51-fb61-45fc-87b8-26d192a7c2bc
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://patient-field-ck629j2u.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-erlang262@sha256:d99feefa7973ba43f726356497f54c34a16421aa25a27fa547d2c1add418204e
- ├─────── memory: 512 MiB
- ├────── service: patient-field-ck629j2u
- ├─ private fqdn: httpserver-erlang262-sw2bp.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-erlang262-sw2bp
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-erlang262-sw2bp
+ ├───────── uuid: 1c4a8a51-fb61-45fc-87b8-26d192a7c2bc
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://patient-field-ck629j2u.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-erlang262@sha256:d99feefa7973ba43f726356497f54c34a16421aa25a27fa547d2c1add418204e
+ ├─────── memory: 512 MiB
+ ├────── service: patient-field-ck629j2u
+ ├─ private fqdn: httpserver-erlang262-sw2bp.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-erlang262-sw2bp` and the address is `https://patient-field-ck629j2u.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-erlang262-sw2bp  running  <my-org>/httpserver-erlang262       
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-erlang262-sw2bp  patient-field-ck629j2u.fra.unikraft.app  running  si
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-erlang262-sw2bp
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-erlang262-sw2bp
 ```
@@ -152,12 +166,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-expressjs4.18-node21/README.md
+++ b/httpserver-expressjs4.18-node21/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-expressjs4.18-node21` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/httpserver-expressjs4.18-node21/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-expressjs418-node21:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-expressjs418-node21:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:300
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-expressjs418-node21-lb3p2
- ├───────── uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://calm-ocean-r9x4mk7v.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-expressjs418-node21@sha256:2e7d3f1a9c4b8e05d6f2a3b7c1e4d8f0a2b5c9e3d7f1a4b8
- ├─────── memory: 512 MiB
- ├────── service: calm-ocean-r9x4mk7v
- ├─ private fqdn: httpserver-expressjs418-node21-lb3p2.internal
- └─── private ip: 10.0.3.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-expressjs418-node21-lb3p2
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-expressjs418-node21-lb3p2
+ ├───────── uuid: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://calm-ocean-r9x4mk7v.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-expressjs418-node21@sha256:2e7d3f1a9c4b8e05d6f2a3b7c1e4d8f0a2b5c9e3d7f1a4b8
+ ├─────── memory: 512 MiB
+ ├────── service: calm-ocean-r9x4mk7v
+ ├─ private fqdn: httpserver-expressjs418-node21-lb3p2.internal
+ └─── private ip: 10.0.3.4
+```
+
 In this case, the instance name is `httpserver-expressjs418-node21-lb3p2` and the address is `https://calm-ocean-r9x4mk7v.fra.unikraft.app`.
 They're different for each run.
 
@@ -101,6 +111,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -112,6 +123,7 @@ fra    httpserver-expressjs418-node21-lb3p2  running  <my-org>/httpserver-expres
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -123,12 +135,14 @@ httpserver-expressjs418-node21-lb3p2  calm-ocean-r9x4mk7v.fra...  running  since
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-expressjs418-node21-lb3p2
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-expressjs418-node21-lb3p2
 ```
@@ -180,12 +194,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-flask-redis/README.md
+++ b/httpserver-flask-redis/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-flask-redis` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/httpserver-flask-redis/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -38,6 +44,7 @@ export UKC_METRO=fra
 First, deploy the Redis instance.
 Redis is an internal service (not publicly accessible), reached via the `redis.internal` domain:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build redis/ --output <my-org>/redis:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -m 256M --image <my-org>/redis:latest --domain redis.internal
@@ -45,29 +52,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -M 256Mi --domain redis.internal redis/
 ```
 
 The output shows the Redis instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: redis-o9abw
- ├───────── uuid: 9dd4c7b5-7cc4-4b99-ac70-b10af54ef075
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: redis.internal
- ├──────── image: oci://unikraft.io/<my-org>/redis@sha256:3e35bc6c8048269741a0c0b4b165a10112736c48dbf869c76bb263a237502462
- ├─────── memory: 256 MiB
- ├────── service: sparkling-fire-rnd4o9kb
- ├─ private fqdn: redis-o9abw.internal
- └─── private ip: 10.0.0.41
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:         fra
 name:          redis-09p2q
@@ -91,11 +83,30 @@ timestamps:
 scale-to-zero: policy=idle,stateful=true,cooldown-time=1s
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: redis-o9abw
+ ├───────── uuid: 9dd4c7b5-7cc4-4b99-ac70-b10af54ef075
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: redis.internal
+ ├──────── image: oci://unikraft.io/<my-org>/redis@sha256:3e35bc6c8048269741a0c0b4b165a10112736c48dbf869c76bb263a237502462
+ ├─────── memory: 256 MiB
+ ├────── service: sparkling-fire-rnd4o9kb
+ ├─ private fqdn: redis-o9abw.internal
+ └─── private ip: 10.0.0.41
+```
+
 ### Deploy Flask
 
 Next, deploy the Flask web server.
 It connects to Redis using the `REDIS_HOST` and `REDIS_PORT` environment variables:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build flask/ --output <my-org>/flask:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8000/tls+http -m 512M --image <my-org>/flask:latest --env REDIS_HOST=redis.internal --env REDIS_PORT=6379
@@ -103,29 +114,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:800
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8000/tls+http -M 512Mi flask/ --env REDIS_HOST=redis.internal --env REDIS_PORT=6379
 ```
 
 The output shows the Flask instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: flask-a06h2
- ├───────── uuid: 431f67ed-1f18-4dc1-86db-68dac4edff51
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://withered-cherry-xfcrfp93.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/flask@sha256:3d29ca3a8a3d434f41acf7c8093435836dcbacca9190c51ec39dbb4ddf1ee45a
- ├─────── memory: 512 MiB
- ├────── service: withered-cherry-xfcrfp93
- ├─ private fqdn: flask-a06h2.internal
- └─── private ip: 10.0.0.53
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:          fra
 name:           flask-q62qa
@@ -151,6 +147,24 @@ networks:
 timestamps:
   created:      just now
 scale-to-zero:  policy=on,cooldown-time=1s
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: flask-a06h2
+ ├───────── uuid: 431f67ed-1f18-4dc1-86db-68dac4edff51
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://withered-cherry-xfcrfp93.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/flask@sha256:3d29ca3a8a3d434f41acf7c8093435836dcbacca9190c51ec39dbb4ddf1ee45a
+ ├─────── memory: 512 MiB
+ ├────── service: withered-cherry-xfcrfp93
+ ├─ private fqdn: flask-a06h2.internal
+ └─── private ip: 10.0.0.53
 ```
 
 In this case, the Flask instance address is `https://withered-cherry-xfcrfp93.fra.unikraft.app`.
@@ -179,12 +193,14 @@ This webpage has been viewed 2 time(s)
 
 You can list information about the instances by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -193,6 +209,7 @@ kraft cloud instance list
 
 When done, remove the instances:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete flask-q62qa
 unikraft instances delete redis-09p2q
@@ -200,6 +217,7 @@ unikraft instances delete redis-09p2q
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove flask-a06h2
 kraft cloud instance remove redis-o9abw

--- a/httpserver-gcc13.2/README.md
+++ b/httpserver-gcc13.2/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-gcc13.2` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-gcc13.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-gcc132:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-gcc132:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-gcc132-is2s9
- ├───────── uuid: bec814ce-6ed5-4858-b247-e7f0b17750f5
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://still-resonance-bja3lste.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-gcc132@sha256:375677bf052f14c18ca79c86d2f47a68f3ea5f8636bcd8830753a254f0e06c1b
- ├─────── memory: 256 MiB
- ├────── service: still-resonance-bja3lste
- ├─ private fqdn: httpserver-gcc132-is2s9.internal
- └─── private ip: 10.0.0.49
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-gcc132-is2s9
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-gcc132-is2s9
+ ├───────── uuid: bec814ce-6ed5-4858-b247-e7f0b17750f5
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://still-resonance-bja3lste.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-gcc132@sha256:375677bf052f14c18ca79c86d2f47a68f3ea5f8636bcd8830753a254f0e06c1b
+ ├─────── memory: 256 MiB
+ ├────── service: still-resonance-bja3lste
+ ├─ private fqdn: httpserver-gcc132-is2s9.internal
+ └─── private ip: 10.0.0.49
+```
+
 In this case, the instance name is `httpserver-gcc132-is2s9` and the address is `https://still-resonance-bja3lste.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-gcc132-is2s9  standby  <my-org>/httpserver-gcc132        256Mi
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-gcc132-is2s9  still-resonance-bja3lste.fra.unikraft.app  standby  sta
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-gcc132-is2s9
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-gcc132-is2s9
 ```
@@ -136,12 +150,14 @@ kraft cloud instance remove httpserver-gcc132-is2s9
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-go1.21/README.md
+++ b/httpserver-go1.21/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-go1.21/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-go1.21/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-go121:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-go121:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-go121-9a2wv
- ├───────── uuid: 8bb34040-9434-4a28-bd1e-c24ee532e2da
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://red-dew-jtk6yxk1.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-go121@sha256:b16d61bb7898e764d8c11ab5a0b995e8c25a25b5ff89e161fc994ebf25a75680
- ├─────── memory: 256 MiB
- ├────── service: red-dew-jtk6yxk1
- ├─ private fqdn: httpserver-go121-9a2wv.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-go121-9a2wv
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-go121-9a2wv
+ ├───────── uuid: 8bb34040-9434-4a28-bd1e-c24ee532e2da
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://red-dew-jtk6yxk1.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-go121@sha256:b16d61bb7898e764d8c11ab5a0b995e8c25a25b5ff89e161fc994ebf25a75680
+ ├─────── memory: 256 MiB
+ ├────── service: red-dew-jtk6yxk1
+ ├─ private fqdn: httpserver-go121-9a2wv.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-go121-9a2wv` and the address is `https://red-dew-jtk6yxk1.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ hello, world!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-go121-9a2wv  running  <my-org>/httpserver-go121        256MiB 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-go121-9a2wv  red-dew-jtk6yxk1.fra.unikraft.app  running  1 minute ago
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-go121-9a2wv
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-go121-9a2wv
 ```
@@ -156,12 +170,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-gpp13.2/README.md
+++ b/httpserver-gpp13.2/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [example repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-gpp13.2/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-gpp13.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-gpp132:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-gpp132:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-gpp132-jzbuo
- ├───────── uuid: b8e015fd-d006-49d5-849e-3fd497c9159a
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://throbbing-wave-grxjih4t.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-gpp132@sha256:a58873987104b52c13b79168a2e2f1a81876ba6efacd6dbc98e996afe5c09699
- ├─────── memory: 256 MiB
- ├────── service: throbbing-wave-grxjih4t
- ├─ private fqdn: httpserver-gpp132-jzbuo.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-gpp132-jzbuo
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-gpp132-jzbuo
+ ├───────── uuid: b8e015fd-d006-49d5-849e-3fd497c9159a
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://throbbing-wave-grxjih4t.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-gpp132@sha256:a58873987104b52c13b79168a2e2f1a81876ba6efacd6dbc98e996afe5c09699
+ ├─────── memory: 256 MiB
+ ├────── service: throbbing-wave-grxjih4t
+ ├─ private fqdn: httpserver-gpp132-jzbuo.internal
+ └─── private ip: 10.0.6.5
+```
+
 In this case, the instance name is `httpserver-gpp132-jzbuo` and the address is `https://throbbing-wave-grxjih4t.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-gpp132-jzbuo  running  <my-org>/httpserver-gpp132        256Mi
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-gpp132-jzbuo  throbbing-wave-grxjih4t.fra.unikraft.app  running  1 mi
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-gpp132-jzbuo
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-gpp132-jzbuo
 ```
@@ -170,12 +184,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-java17-spring-petclinic/README.md
+++ b/httpserver-java17-spring-petclinic/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-java17-spring-petclinic/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/httpserver-java17-spring-petclinic/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-java17-spring-petclinic:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/httpserver-java17-spring-petclinic:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s --metro fra -p 443:8080/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-java17-spring-petclinic-r4s3x
- ├───────── uuid: 5a3b7e2c-1f4d-4a8e-b6c9-2d3f8a1e7b4c
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://bitter-dust-a7b2c3d4.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-java17-spring-petclinic@sha256:3e9d1f8a7b2c4e5f6a3b8c2d1e4f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f
- ├─────── memory: 1024 MiB
- ├────── service: bitter-dust-a7b2c3d4
- ├─ private fqdn: httpserver-java17-spring-petclinic-r4s3x.internal
- └─── private ip: 10.0.4.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-java17-spring-petclinic-r4s3x
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-java17-spring-petclinic-r4s3x
+ ├───────── uuid: 5a3b7e2c-1f4d-4a8e-b6c9-2d3f8a1e7b4c
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://bitter-dust-a7b2c3d4.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-java17-spring-petclinic@sha256:3e9d1f8a7b2c4e5f6a3b8c2d1e4f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f
+ ├─────── memory: 1024 MiB
+ ├────── service: bitter-dust-a7b2c3d4
+ ├─ private fqdn: httpserver-java17-spring-petclinic-r4s3x.internal
+ └─── private ip: 10.0.4.2
+```
+
 In this case, the instance name is `httpserver-java17-spring-petclinic-r4s3x` and the address is `https://bitter-dust-a7b2c3d4.fra.unikraft.app`.
 They're different for each run.
 
@@ -93,6 +103,7 @@ After deploying, point your browser to the provided URL.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -104,6 +115,7 @@ fra    httpserver-java17-spring-petclinic-r4s3x  running  <my-org>/httpserver-ja
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -115,12 +127,14 @@ httpserver-java17-spring-petclinic-r4s3x  bitter-dust-a7b2c3d4.fra.unikraft.app 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -135,12 +149,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-java17-springboot3.5.x/README.md
+++ b/httpserver-java17-springboot3.5.x/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-java17-springboot3.5.x/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-java17-springboot3.5.x/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-java17-springboot35x:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/httpserver-java17-springboot35x:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-java17-springboot35x-qseeo
- ├───────── uuid: b081166d-a2a0-43af-982d-1aa17f06b5c4
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://long-dust-si7xsngk.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-java17-springboot35x@sha256:cc2f2ad18ce8e36b8e8f4debee096fef7b0bb8b47762575a2ba5a9de8199c64a
- ├─────── memory: 1024 MiB
- ├────── service: long-dust-si7xsngk
- ├─ private fqdn: httpserver-java17-springboot35x-qseeo.internal
- └─── private ip: 10.0.6.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-java17-springboot35x-qseeo
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-java17-springboot35x-qseeo
+ ├───────── uuid: b081166d-a2a0-43af-982d-1aa17f06b5c4
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://long-dust-si7xsngk.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-java17-springboot35x@sha256:cc2f2ad18ce8e36b8e8f4debee096fef7b0bb8b47762575a2ba5a9de8199c64a
+ ├─────── memory: 1024 MiB
+ ├────── service: long-dust-si7xsngk
+ ├─ private fqdn: httpserver-java17-springboot35x-qseeo.internal
+ └─── private ip: 10.0.6.2
+```
+
 In this case, the instance name is `httpserver-java17-springboot35x-qseeo` and the address is `https://long-dust-si7xsngk.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,12 +110,14 @@ Hello World!
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-java17-springboot35x-qseeo
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-java17-springboot35x-qseeo
 ```
@@ -146,6 +158,7 @@ The following options are available for customizing the app:
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -157,6 +170,7 @@ fra    httpserver-java17-springboot35x-qseeo  running  <my-org>/httpserver-java1
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -168,12 +182,14 @@ httpserver-java17-springboot35x-qseeo  long-dust-si7xsngk.fra.unikraft.app  runn
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-java17-springboot35x-qseeo
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-java17-springboot35x-qseeo
 ```
@@ -183,12 +199,14 @@ kraft cloud instance remove httpserver-java17-springboot35x-qseeo
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-java21/README.md
+++ b/httpserver-java21/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-java21` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/httpserver-java21/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-java21:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/httpserver-java21:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-java21-5xw9m
- ├───────── uuid: b2c3d4e5-f6a7-8901-bcde-f12345678901
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://gentle-wind-b2x9pkqm.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-java21@sha256:4f8a2c6e1d9b3f7a5c0e2b4d8f6a1c3e7b9d2f4a6c8e0b2d4f6a8c0e2b4d6f
- ├─────── memory: 1 GiB
- ├────── service: gentle-wind-b2x9pkqm
- ├─ private fqdn: httpserver-java21-5xw9m.internal
- └─── private ip: 10.0.3.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-java21-5xw9m
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-java21-5xw9m
+ ├───────── uuid: b2c3d4e5-f6a7-8901-bcde-f12345678901
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://gentle-wind-b2x9pkqm.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-java21@sha256:4f8a2c6e1d9b3f7a5c0e2b4d8f6a1c3e7b9d2f4a6c8e0b2d4f6a8c0e2b4d6f
+ ├─────── memory: 1 GiB
+ ├────── service: gentle-wind-b2x9pkqm
+ ├─ private fqdn: httpserver-java21-5xw9m.internal
+ └─── private ip: 10.0.3.5
+```
+
 In this case, the instance name is `httpserver-java21-5xw9m` and the address is `https://gentle-wind-b2x9pkqm.fra.unikraft.app`.
 They're different for each run.
 
@@ -101,6 +111,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -112,6 +123,7 @@ fra    httpserver-java21-5xw9m  running  <my-org>/httpserver-java21        1GiB 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -123,12 +135,14 @@ httpserver-java21-5xw9m  gentle-wind-b2x9pkqm.fra.unik...  running  since 3mins 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-java21-5xw9m
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-java21-5xw9m
 ```
@@ -184,12 +198,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-lua5.1/README.md
+++ b/httpserver-lua5.1/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-lua5.1/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-lua5.1/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-lua51:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-lua51:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-lua51-ma2i9
- ├───────── uuid: e7389eee-9808-4152-b2ec-1f3c0541fd05
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://young-night-5fpf0jj8.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-lua51@sha256:278cb8b14f9faf9c2702dddd8bfb6124912d82c11b4a2c6590b6e32fc4049472
- ├─────── memory: 256 MiB
- ├────── service: young-night-5fpf0jj8
- ├─ private fqdn: httpserver-lua51-ma2i9.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-lua51-ma2i9
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-lua51-ma2i9
+ ├───────── uuid: e7389eee-9808-4152-b2ec-1f3c0541fd05
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://young-night-5fpf0jj8.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-lua51@sha256:278cb8b14f9faf9c2702dddd8bfb6124912d82c11b4a2c6590b6e32fc4049472
+ ├─────── memory: 256 MiB
+ ├────── service: young-night-5fpf0jj8
+ ├─ private fqdn: httpserver-lua51-ma2i9.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-lua51-ma2i9` and the address is `https://young-night-5fpf0jj8.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-lua51-ma2i9  running  <my-org>/httpserver-lua51        256MiB 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-lua51-ma2i9  young-night-5fpf0jj8.fra.unikraft.app  running  1 minute
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-lua51-ma2i9
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-lua51-ma2i9
 ```
@@ -152,12 +166,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-nginx-vite-vanilla/README.md
+++ b/httpserver-nginx-vite-vanilla/README.md
@@ -11,6 +11,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-nginx-vite-vanilla` directory:
 
 ```bash
@@ -21,12 +25,14 @@ cd examples/httpserver-nginx-vite-vanilla/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -36,6 +42,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-nginx-vite-vanilla:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-nginx-vite-vanilla:latest
@@ -43,29 +50,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-nginx-vite-vanilla-2rk6p
- ├───────── uuid: d4e5f6a7-b8c9-0123-defa-234567890123
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://swift-lake-m4n8vqzp.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-nginx-vite-vanilla@sha256:9c5f2d8b4e7a1c3f6d9b2e5a8c1f4d7a0b3e6c9f2d5a8b1e4c7f0d3a6b9c2
- ├─────── memory: 256 MiB
- ├────── service: swift-lake-m4n8vqzp
- ├─ private fqdn: httpserver-nginx-vite-vanilla-2rk6p.internal
- └─── private ip: 10.0.3.7
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-nginx-vite-vanilla-2rk6p
@@ -86,6 +78,24 @@ networks:
   mac:        12:b0:1a:5c:59:a9
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-nginx-vite-vanilla-2rk6p
+ ├───────── uuid: d4e5f6a7-b8c9-0123-defa-234567890123
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://swift-lake-m4n8vqzp.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-nginx-vite-vanilla@sha256:9c5f2d8b4e7a1c3f6d9b2e5a8c1f4d7a0b3e6c9f2d5a8b1e4c7f0d3a6b9c2
+ ├─────── memory: 256 MiB
+ ├────── service: swift-lake-m4n8vqzp
+ ├─ private fqdn: httpserver-nginx-vite-vanilla-2rk6p.internal
+ └─── private ip: 10.0.3.7
 ```
 
 In this case, the instance name is `httpserver-nginx-vite-vanilla-2rk6p` and the address is `https://swift-lake-m4n8vqzp.fra.unikraft.app`.
@@ -113,6 +123,7 @@ curl https://swift-lake-m4n8vqzp.fra.unikraft.app
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -124,6 +135,7 @@ fra    httpserver-nginx-vite-vanilla-2rk6p  running  <my-org>/httpserver-nginx-v
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -135,12 +147,14 @@ httpserver-nginx-vite-vanilla-2rk6p  swift-lake-m4n8vqzp.fra.unikraft.app  runni
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-nginx-vite-vanilla-2rk6p
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-nginx-vite-vanilla-2rk6p
 ```
@@ -193,12 +207,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node-express-puppeteer/README.md
+++ b/httpserver-node-express-puppeteer/README.md
@@ -9,6 +9,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node-express-puppeteer/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/httpserver-node-express-puppeteer/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -41,6 +47,7 @@ The `UKC_TOKEN` and `UKC_METRO` environment variables are only supported by the 
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node-express-puppeteer:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 4G --image <my-org>/httpserver-node-express-puppeteer:latest
@@ -48,29 +55,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node-express-puppeteer-7afg3
- ├───────── uuid: 7bb479d7-5b3e-444f-b07c-eae4da6f57cc
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://nameless-fog-0tvh1uov.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node-express-puppeteer@sha256:78d0b180161c876f17d05116b93011ddcd44c76758d6fa0359f05938e67cea65
- ├─────── memory: 4096 MiB
- ├────── service: little-snow-7qwu6vv5
- ├─ private fqdn: httpserver-node-express-puppeteer-7afg3.internal
- └─── private ip: 10.0.3.1
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node-express-puppeteer-7afg3
@@ -93,6 +85,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node-express-puppeteer-7afg3
+ ├───────── uuid: 7bb479d7-5b3e-444f-b07c-eae4da6f57cc
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://nameless-fog-0tvh1uov.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node-express-puppeteer@sha256:78d0b180161c876f17d05116b93011ddcd44c76758d6fa0359f05938e67cea65
+ ├─────── memory: 4096 MiB
+ ├────── service: little-snow-7qwu6vv5
+ ├─ private fqdn: httpserver-node-express-puppeteer-7afg3.internal
+ └─── private ip: 10.0.3.1
+```
+
 In this case, the instance name is `httpserver-node-express-puppeteer-7afg3`.
 They're different for each run.
 
@@ -104,6 +114,7 @@ You can use the landing page to generate the PDF version of a remote page.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -115,6 +126,7 @@ fra    httpserver-node-express-puppeteer-7afg3  running  <my-org>/httpserver-nod
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -126,12 +138,14 @@ httpserver-node-express-puppeteer-7afg3  nameless-fog-0tvh1uov.fra.unikraft.app 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-node-express-puppeteer-7afg3
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-node-express-puppeteer-7afg3
 ```

--- a/httpserver-node-vite-ssr-vanilla/README.md
+++ b/httpserver-node-vite-ssr-vanilla/README.md
@@ -25,6 +25,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node-vite-ssr-vanilla/` directory:
 
 ```bash
@@ -35,12 +39,14 @@ cd examples/httpserver-node-vite-ssr-vanilla/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -50,6 +56,7 @@ export UKC_METRO=fra
 
 When done, run:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node-vite-ssr-vanilla:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro fra -p 443:8080/tls+http -m 1G -e PWD=/app -e NODE_ENV=production --image <my-org>/httpserver-node-vite-ssr-vanilla:latest
@@ -57,29 +64,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 2s -p 443:8080/tls+http -M 1Gi -e PWD=/app -e NODE_ENV=production .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node-vite-ssr-vanilla-k8x2m
- ├───────── uuid: 1a2b3c4d-5e6f-7a8b-9c0d-a1b2c3d4e5f6
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://warm-sky-qp3mn4rs.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node-vite-ssr-vanilla@sha256:4f8a2c6e1b3d5f7a9c0e2b4d6f8a0c2e4b6d8f0a2c4e6b8d0f2a4c6e8b0d2f4a
- ├─────── memory: 1024 MiB
- ├────── service: warm-sky-qp3mn4rs
- ├─ private fqdn: httpserver-node-vite-ssr-vanilla-k8x2m.internal
- └─── private ip: 10.0.3.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node-vite-ssr-vanilla-k8x2m
@@ -102,6 +94,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node-vite-ssr-vanilla-k8x2m
+ ├───────── uuid: 1a2b3c4d-5e6f-7a8b-9c0d-a1b2c3d4e5f6
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://warm-sky-qp3mn4rs.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node-vite-ssr-vanilla@sha256:4f8a2c6e1b3d5f7a9c0e2b4d6f8a0c2e4b6d8f0a2c4e6b8d0f2a4c6e8b0d2f4a
+ ├─────── memory: 1024 MiB
+ ├────── service: warm-sky-qp3mn4rs
+ ├─ private fqdn: httpserver-node-vite-ssr-vanilla-k8x2m.internal
+ └─── private ip: 10.0.3.4
+```
+
 In this case, the instance name is `httpserver-node-vite-ssr-vanilla-k8x2m` and the address is `https://warm-sky-qp3mn4rs.fra.unikraft.app`.
 They're different for each run.
 
@@ -110,6 +120,7 @@ After deploying, you can query the service using the provided URL.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -121,6 +132,7 @@ fra    httpserver-node-vite-ssr-vanilla-k8x2m  running  <my-org>/httpserver-node
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -132,12 +144,14 @@ httpserver-node-vite-ssr-vanilla-k8x2m  warm-sky-qp3mn4rs.fra.unikraft.app  runn
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -155,12 +169,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node-vite-vanilla/README.md
+++ b/httpserver-node-vite-vanilla/README.md
@@ -29,6 +29,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node-vite-vanilla/` directory:
 
 ```bash
@@ -39,12 +43,14 @@ cd examples/httpserver-node-vite-vanilla/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -54,6 +60,7 @@ export UKC_METRO=fra
 
 When done, run:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node-vite-vanilla:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro fra -p 443:8080/tls+http -m 4G -e PWD=/app --image <my-org>/httpserver-node-vite-vanilla:latest
@@ -61,29 +68,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 2s -p 443:8080/tls+http -M 4Gi -e PWD=/app .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node-vite-vanilla-w9f3p
- ├───────── uuid: 4d5e6f7a-8b9c-0d1e-2f3a-d4e5f6a7b8c9
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://bold-rain-mv5tx8wy.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node-vite-vanilla@sha256:5a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b
- ├─────── memory: 4096 MiB
- ├────── service: bold-rain-mv5tx8wy
- ├─ private fqdn: httpserver-node-vite-vanilla-w9f3p.internal
- └─── private ip: 10.0.5.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node-vite-vanilla-w9f3p
@@ -106,6 +98,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node-vite-vanilla-w9f3p
+ ├───────── uuid: 4d5e6f7a-8b9c-0d1e-2f3a-d4e5f6a7b8c9
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://bold-rain-mv5tx8wy.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node-vite-vanilla@sha256:5a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b
+ ├─────── memory: 4096 MiB
+ ├────── service: bold-rain-mv5tx8wy
+ ├─ private fqdn: httpserver-node-vite-vanilla-w9f3p.internal
+ └─── private ip: 10.0.5.2
+```
+
 In this case, the instance name is `httpserver-node-vite-vanilla-w9f3p` and the address is `https://bold-rain-mv5tx8wy.fra.unikraft.app`.
 They're different for each run.
 
@@ -114,6 +124,7 @@ After deploying, you can query the service using the provided URL.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -125,6 +136,7 @@ fra    httpserver-node-vite-vanilla-w9f3p  running  <my-org>/httpserver-node-vit
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -136,12 +148,14 @@ httpserver-node-vite-vanilla-w9f3p  bold-rain-mv5tx8wy.fra.unikraft.app  running
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -159,12 +173,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node21-nextjs/README.md
+++ b/httpserver-node21-nextjs/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node21-nextjs` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-node21-nextjs/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node21-nextjs:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 768M --image <my-org>/httpserver-node21-nextjs:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 768Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node21-nextjs-bfrq0
- ├───────── uuid: 2adf9664-c4ae-4e0e-99de-c9781282b370
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://small-frog-ri8c1vtw.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node21-nextjs@sha256:ea5b2f145eea9762431ebdea933dd1dfb8427fe23306d2bd7966dd502d6c88f6
- ├─────── memory: 768 MiB
- ├────── service: small-frog-ri8c1vtw
- ├─ private fqdn: httpserver-node21-nextjs-bfrq0.internal
- └─── private ip: 10.0.28.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node21-nextjs-bfrq0
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node21-nextjs-bfrq0
+ ├───────── uuid: 2adf9664-c4ae-4e0e-99de-c9781282b370
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://small-frog-ri8c1vtw.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node21-nextjs@sha256:ea5b2f145eea9762431ebdea933dd1dfb8427fe23306d2bd7966dd502d6c88f6
+ ├─────── memory: 768 MiB
+ ├────── service: small-frog-ri8c1vtw
+ ├─ private fqdn: httpserver-node21-nextjs-bfrq0.internal
+ └─── private ip: 10.0.28.2
+```
+
 In this case, the instance name is `httpserver-node21-nextjs-bfrq0` and the address is `https://small-frog-ri8c1vtw.fra.unikraft.app`.
 They're different for each run.
 
@@ -102,6 +112,7 @@ Or even better, point a browser at it 😀.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -113,6 +124,7 @@ fra    httpserver-node21-nextjs-bfrq0  running  <my-org>/httpserver-node21-nextj
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,12 +136,14 @@ httpserver-node21-nextjs-bfrq0  small-frog-ri8c1vtw.fra.unikraft.app  running  1
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-node21-nextjs-bfrq0
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-node21-nextjs-bfrq0
 ```
@@ -184,6 +198,7 @@ cd examples/httpserver-expressjs4.18-node21/
 
 Run the command below to deploy the app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-expressjs418-node21:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 256M --image <my-org>/httpserver-expressjs418-node21:latest
@@ -191,6 +206,7 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 256Mi .
 ```
@@ -243,12 +259,14 @@ See also other Node examples: [`httpserver-node18-prisma-rest-express`](https://
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node21-solid-start/README.md
+++ b/httpserver-node21-solid-start/README.md
@@ -8,6 +8,10 @@ To do so, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node21-solid-start/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-node21-solid-start/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node21-solid-start:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-node21-solid-start:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:300
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node21-solid-start-lvoa2
- ├───────── uuid: 4e6ccb1f-0533-4dc1-be67-eca8dfc1f8c6
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://long-star-1tms9h1z.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node21-solid-start@sha256:eb2e79b2fc5c28bb43923a1fc4931db94ebc3f939a6fbe00d06189c0ae2e02fd
- ├─────── memory: 512 MiB
- ├────── service: long-star-1tms9h1z
- ├─ private fqdn: httpserver-node21-solid-start-lvoa2.internal
- └─── private ip: 10.0.6.8
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node21-solid-start-lvoa2
@@ -85,12 +77,31 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node21-solid-start-lvoa2
+ ├───────── uuid: 4e6ccb1f-0533-4dc1-be67-eca8dfc1f8c6
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://long-star-1tms9h1z.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node21-solid-start@sha256:eb2e79b2fc5c28bb43923a1fc4931db94ebc3f939a6fbe00d06189c0ae2e02fd
+ ├─────── memory: 512 MiB
+ ├────── service: long-star-1tms9h1z
+ ├─ private fqdn: httpserver-node21-solid-start-lvoa2.internal
+ └─── private ip: 10.0.6.8
+```
+
 In this case, the instance name is `httpserver-node21-solid-start-lvoa2` and the address is `https://long-star-1tms9h1z.fra.unikraft.app`.
 They're different for each run.
 You can now point your browser at the address to see your deployed instance.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -102,6 +113,7 @@ fra    httpserver-node21-solid-start-lvoa2  running  <my-org>/httpserver-node21-
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -113,12 +125,14 @@ httpserver-node21-solid-start-lvoa2  long-star-1tms9h1z.fra.unikraft.app  runnin
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-node21-solid-start-lvoa2
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-node21-solid-start-lvoa2
 ```
@@ -135,12 +149,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node22-react-router/README.md
+++ b/httpserver-node22-react-router/README.md
@@ -9,6 +9,10 @@ To do so, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node22-react-router/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/httpserver-node22-react-router/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node22-react-router:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:3000/tls+http -m 768M --image <my-org>/httpserver-node22-react-router:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:300
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 768Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node22-react-router-jvj6b
- ├───────── uuid: 4e6ccb1f-0533-4dc1-be67-eca8dfc1f8c6
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://long-star-1tms9h1z.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node22-react-router@sha256:300eefce3de136ad9c782f010b69da01100ae5f0ca17f038f92321d735d6675f
- ├─────── memory: 768 MiB
- ├────── service: long-star-1tms9h1z
- ├─ private fqdn: httpserver-node22-react-router-jvj6b.internal
- └─── private ip: 10.0.6.8
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node22-react-router-jvj6b
@@ -86,12 +78,31 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node22-react-router-jvj6b
+ ├───────── uuid: 4e6ccb1f-0533-4dc1-be67-eca8dfc1f8c6
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://long-star-1tms9h1z.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node22-react-router@sha256:300eefce3de136ad9c782f010b69da01100ae5f0ca17f038f92321d735d6675f
+ ├─────── memory: 768 MiB
+ ├────── service: long-star-1tms9h1z
+ ├─ private fqdn: httpserver-node22-react-router-jvj6b.internal
+ └─── private ip: 10.0.6.8
+```
+
 In this case, the instance name is `httpserver-node22-react-router-jvj6b` and the address is `https://long-star-1tms9h1z.fra.unikraft.app`.
 They're different for each run.
 You can now point your browser at the address to see your deployed instance.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -103,6 +114,7 @@ fra    httpserver-node22-react-router-jvj6b  running  <my-org>/httpserver-node22
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -114,12 +126,14 @@ httpserver-node22-react-router-jvj6b  long-star-1tms9h1z.fra.unikraft.app  runni
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-node22-react-router-jvj6b
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-node22-react-router-jvj6b
 ```
@@ -136,12 +150,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node22-sveltekit/README.md
+++ b/httpserver-node22-sveltekit/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node22-sveltekit/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/httpserver-node22-sveltekit/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node22-sveltekit:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-node22-sveltekit:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:300
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node22-sveltekit-zmt39
- ├───────── uuid: cd5071b0-5605-4771-b75d-4789393e60de
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://dark-fog-z18n0ej1.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node22-sveltekit@sha256:4cea210aef3513bd68490640b511ebcff2b867e9222028b9938faccffc21cb83
- ├─────── memory: 512 MiB
- ├────── service: dark-fog-z18n0ej1
- ├─ private fqdn: httpserver-node22-sveltekit-zmt39.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node22-sveltekit-zmt39
@@ -85,6 +77,24 @@ networks:
   mac:        12:b0:a0:31:90:5a
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node22-sveltekit-zmt39
+ ├───────── uuid: cd5071b0-5605-4771-b75d-4789393e60de
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://dark-fog-z18n0ej1.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node22-sveltekit@sha256:4cea210aef3513bd68490640b511ebcff2b867e9222028b9938faccffc21cb83
+ ├─────── memory: 512 MiB
+ ├────── service: dark-fog-z18n0ej1
+ ├─ private fqdn: httpserver-node22-sveltekit-zmt39.internal
+ └─── private ip: 10.0.3.3
 ```
 
 In this case, the instance name is `httpserver-node22-sveltekit-zmt39` and the address is `https://dark-fog-z18n0ej1.fra.unikraft.app`.
@@ -109,6 +119,7 @@ This will get you to play with the SvelteKit demo app.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -120,6 +131,7 @@ fra    httpserver-node22-sveltekit-zmt39  running  <my-org>/httpserver-node22-sv
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -131,12 +143,14 @@ httpserver-node22-sveltekit-zmt39  dark-fog-z18n0ej1.fra.unikraft.app  running  
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-node22-sveltekit-zmt39
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-node22-sveltekit-zmt39
 ```
@@ -240,12 +254,14 @@ Still, if required, apps may require extending the `Dockerfile` with extra [`Doc
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-node25/README.md
+++ b/httpserver-node25/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-node25` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/httpserver-node25/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-node25:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-node25:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-node25-v8mp4
- ├───────── uuid: c3d4e5f6-a7b8-9012-cdef-123456789012
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://bright-star-k3m7pqnx.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-node25@sha256:7b3e1f9d5a2c8e4b0f6d3a7c5e2b9f4d1a8c6e3b0f7d4a1c8e5b2f9d6a3c0
- ├─────── memory: 512 MiB
- ├────── service: bright-star-k3m7pqnx
- ├─ private fqdn: httpserver-node25-v8mp4.internal
- └─── private ip: 10.0.3.6
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-node25-v8mp4
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-node25-v8mp4
+ ├───────── uuid: c3d4e5f6-a7b8-9012-cdef-123456789012
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://bright-star-k3m7pqnx.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-node25@sha256:7b3e1f9d5a2c8e4b0f6d3a7c5e2b9f4d1a8c6e3b0f7d4a1c8e5b2f9d6a3c0
+ ├─────── memory: 512 MiB
+ ├────── service: bright-star-k3m7pqnx
+ ├─ private fqdn: httpserver-node25-v8mp4.internal
+ └─── private ip: 10.0.3.6
+```
+
 In this case, the instance name is `httpserver-node25-v8mp4` and the address is `https://bright-star-k3m7pqnx.fra.unikraft.app`.
 They're different for each run.
 
@@ -101,6 +111,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -112,6 +123,7 @@ fra    httpserver-node25-v8mp4  running  <my-org>/httpserver-node25        512Mi
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -123,12 +135,14 @@ httpserver-node25-v8mp4  bright-star-k3m7pqnx.fra.unikraft.app  running  since 3
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-node25-v8mp4
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-node25-v8mp4
 ```
@@ -180,12 +194,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-perl5.42/README.md
+++ b/httpserver-perl5.42/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-perl5.42/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-perl5.42/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-perl542:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-perl542:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-perl542-xue8j
- ├───────── uuid: 59d08bbc-cbb7-4c6b-a2cb-847828845db9
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://fragrant-water-wau08gaw.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-perl542@sha256:af86e8f03c0d4cfd596ccfd9a9d18ea75ac68c996c9cde31f64db24dc11100fe
- ├─────── memory: 512 MiB
- ├────── service: fragrant-water-wau08gaw
- ├─ private fqdn: httpserver-perl542-xue8j.internal
- └─── private ip: 10.0.1.161
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-perl542-xue8j
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-perl542-xue8j
+ ├───────── uuid: 59d08bbc-cbb7-4c6b-a2cb-847828845db9
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://fragrant-water-wau08gaw.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-perl542@sha256:af86e8f03c0d4cfd596ccfd9a9d18ea75ac68c996c9cde31f64db24dc11100fe
+ ├─────── memory: 512 MiB
+ ├────── service: fragrant-water-wau08gaw
+ ├─ private fqdn: httpserver-perl542-xue8j.internal
+ └─── private ip: 10.0.1.161
+```
+
 In this case, the instance name is `httpserver-perl542-xue8j` and the address is `https://fragrant-water-wau08gaw.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-perl542-xue8j  standby  <my-org>/httpserver-perl542        512
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,6 +136,7 @@ When you list your instances, you might notice they show as standby.
 This is normal behavior and means the instance is using Unikraft Cloud's scale-to-zero feature that saves resources when there is no traffic.
 To check your instance is working, open two terminals and use these commands to watch the status:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instance list --watch
 # In another terminal, make requests
@@ -132,6 +145,7 @@ curl https://fragrant-water-wau08gaw.fra.unikraft.app
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 watch -n 1 "kraft cloud instance list"
 # In another terminal, make requests
@@ -142,12 +156,14 @@ It switches to "running" then back to "standby."
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-perl542-xue8j
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-perl542-xue8j
 ```
@@ -172,12 +188,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-php8.2/README.md
+++ b/httpserver-php8.2/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-php8.2/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-php8.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-php82:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-php82:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-php82-g00si
- ├───────── uuid: 033b2f4b-72ff-414d-b0de-63571477c657
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://aged-fire-rh0oi0tj.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-php82@sha256:dccaac053982673765b8f00497a9736c31458ab23ad59a550b09aa8dedfabb34
- ├─────── memory: 512 MiB
- ├────── service: aged-fire-rh0oi0tj
- ├─ private fqdn: httpserver-php82-g00si.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-php82-g00si
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-php82-g00si
+ ├───────── uuid: 033b2f4b-72ff-414d-b0de-63571477c657
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://aged-fire-rh0oi0tj.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-php82@sha256:dccaac053982673765b8f00497a9736c31458ab23ad59a550b09aa8dedfabb34
+ ├─────── memory: 512 MiB
+ ├────── service: aged-fire-rh0oi0tj
+ ├─ private fqdn: httpserver-php82-g00si.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-php82-g00si` and the address is `https://aged-fire-rh0oi0tj.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-php82-g00si  running  <my-org>/httpserver-php82        512MiB 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-php82-g00si  aged-fire-rh0oi0tj.fra.unikraft.app  running  50 seconds
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-php82-g00si
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-php82-g00si
 ```
@@ -154,12 +168,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-prisma-expressjs4.19-node18/README.md
+++ b/httpserver-prisma-expressjs4.19-node18/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-prisma-expressjs4.19-node18/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/httpserver-prisma-expressjs4.19-node18/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-prisma-expressjs419-node18:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:3000/tls+http -m 512M --image <my-org>/httpserver-prisma-expressjs419-node18:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:300
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-prisma-expressjs419-node18-hdof1
- ├───────── uuid: 066f55cb-bcbd-45e5-9f6b-b3866c3a3a4c
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://funky-sun-4bf8v7g9.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-prisma-expressjs419-node18@sha256:770d4af1d490daea11171c680eaf99e2a6017a262ba9fbf1ba8d708f5fc32bfe
- ├─────── memory: 512 MiB
- ├────── service: funky-sun-4bf8v7g9
- ├─ private fqdn: httpserver-prisma-expressjs419-node18-hdof1.internal
- └─── private ip: 10.0.28.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-prisma-expressjs419-node18-hdof1
@@ -87,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-prisma-expressjs419-node18-hdof1
+ ├───────── uuid: 066f55cb-bcbd-45e5-9f6b-b3866c3a3a4c
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://funky-sun-4bf8v7g9.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-prisma-expressjs419-node18@sha256:770d4af1d490daea11171c680eaf99e2a6017a262ba9fbf1ba8d708f5fc32bfe
+ ├─────── memory: 512 MiB
+ ├────── service: funky-sun-4bf8v7g9
+ ├─ private fqdn: httpserver-prisma-expressjs419-node18-hdof1.internal
+ └─── private ip: 10.0.28.2
+```
+
 In this case, the instance name is `httpserver-prisma-expressjs419-node18-hdof1` and the address is `https://funky-sun-4bf8v7g9.fra.unikraft.app`.
 They're different for each run.
 
@@ -104,6 +114,7 @@ curl https://funky-sun-4bf8v7g9.fra.unikraft.app/users
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -115,6 +126,7 @@ fra    httpserver-prisma-expressjs419-node18-hdof1  running  <my-org>/httpserver
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -126,12 +138,14 @@ httpserver-prisma-expressjs419-node18-hdof1  funky-sun-4bf8v7g9.fra.unikraft.app
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-prisma-expressjs419-node18-hdof1
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-prisma-expressjs419-node18-hdof1
 ```
@@ -375,12 +389,14 @@ datasource db {
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-python3.12-django5.0/README.md
+++ b/httpserver-python3.12-django5.0/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-python3.12-django5.0/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-python3.12-django5.0/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312-django50:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:80/tls+http -m 1G --image <my-org>/httpserver-python312-django50:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:80/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-python312-django50-vt56c
- ├───────── uuid: d8469447-fdf6-4caf-9fea-494218ca6f72
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://dawn-sound-n5wrkxi2.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-django50@sha256:221666d414299aff54dbf10020b3d540270ee0c5907c1c6a728ca254ce8b0e50
- ├─────── memory: 1024 MiB
- ├────── service: dawn-sound-n5wrkxi2
- ├─ private fqdn: httpserver-python312-django50-vt56c.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-python312-django50-vt56c
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:9c:af:65:e7
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-python312-django50-vt56c
+ ├───────── uuid: d8469447-fdf6-4caf-9fea-494218ca6f72
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://dawn-sound-n5wrkxi2.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-django50@sha256:221666d414299aff54dbf10020b3d540270ee0c5907c1c6a728ca254ce8b0e50
+ ├─────── memory: 1024 MiB
+ ├────── service: dawn-sound-n5wrkxi2
+ ├─ private fqdn: httpserver-python312-django50-vt56c.internal
+ └─── private ip: 10.0.6.5
 ```
 
 In this case, the instance name is `httpserver-python312-django50-vt56c` and the address is `https://dawn-sound-n5wrkxi2.fra.unikraft.app`.
@@ -122,6 +132,7 @@ You can set the username and password in the `Dockerfile` (more on this file lat
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -133,6 +144,7 @@ fra    httpserver-python312-django50-vt56c  running  <my-org>/httpserver-python3
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -144,12 +156,14 @@ httpserver-python312-django50-vt56c  dawn-sound-n5wrkxi2.fra.unikraft.app  runni
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances remove httpserver-python312-django50-vt56c
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-python312-django50-vt56c
 ```
@@ -197,6 +211,7 @@ The [`httpserver-python3.12-flask3.0`](https://github.com/unikraft-cloud/example
 
 Run the command below to deploy the app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312-flask30:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:80/tls+http -m 1G --image <my-org>/httpserver-python312-flask30:latest
@@ -204,6 +219,7 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:80/tls+http -M 1Gi .
 ```
@@ -250,12 +266,14 @@ Similar actions apply to other `pip3`-based apps.
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-python3.12-fastapi-0.121.3/README.md
+++ b/httpserver-python3.12-fastapi-0.121.3/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 1. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-python3.12-fastapi-0.121.3/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-python3.12-fastapi-0.121.3/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312-fastapi-01213:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python312-fastapi-01213:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-python312-fastapi-01213-0n84f
- ├───────── uuid: 5d7fc331-3c23-4953-b025-d152a872ea29
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://dry-water-0oexx89g.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-fastapi-01213@sha256:fb2a00dcf1cfc3ac821cbda05f82f38d66e63121344b9bc60c6a6e2f11917b98
- ├─────── memory: 512 MiB
- ├────── service: dry-water-0oexx89g
- ├─ private fqdn: httpserver-python312-fastapi-01213-0n84f.internal
- └─── private ip: 10.0.1.69
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-python312-fastapi-01213-0n84f
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-python312-fastapi-01213-0n84f
+ ├───────── uuid: 5d7fc331-3c23-4953-b025-d152a872ea29
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://dry-water-0oexx89g.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-fastapi-01213@sha256:fb2a00dcf1cfc3ac821cbda05f82f38d66e63121344b9bc60c6a6e2f11917b98
+ ├─────── memory: 512 MiB
+ ├────── service: dry-water-0oexx89g
+ ├─ private fqdn: httpserver-python312-fastapi-01213-0n84f.internal
+ └─── private ip: 10.0.1.69
+```
+
 In this case, the instance name is `httpserver-python312-fastapi-01213-0n84f` and the address is `https://dry-water-0oexx89g.fra.unikraft.app`.
 They're different for each run.
 
@@ -99,6 +109,7 @@ curl https://dry-water-0oexx89g.fra.unikraft.app
 ```
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -110,6 +121,7 @@ fra    httpserver-python312-fastapi-01213-0n84f  standby  <my-org>/httpserver-py
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -121,12 +133,14 @@ httpserver-python312-fastapi-01213-0n84f  dry-water-0oexx89g.fra.unikraft.app  s
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances remove httpserver-python312-fastapi-01213-0n84f
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-python312-fastapi-01213-0n84f
 ```
@@ -167,12 +181,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-python3.12-flask3.0-sqlite/README.md
+++ b/httpserver-python3.12-flask3.0-sqlite/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-python3.12-flask3.0-sqlite/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-python3.12-flask3.0-sqlite/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312-flask30-sqlite:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 768M --image <my-org>/httpserver-python312-flask30-sqlite:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 768Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-python312-flask30-sqlite-qodkd
- ├───────── uuid: e00e7aca-962d-409c-87c2-c245ca08b54b
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://lingering-orangutan-840mmdvd.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-flask30-sqlite@sha256:bdb0bf35a9675b9b3836cbb626606da0606334d91768c7ba31195c3062d6f517
- ├─────── memory: 768 MiB
- ├────── service: lingering-orangutan-840mmdvd
- ├─ private fqdn: httpserver-python312-flask30-sqlite-qodkd.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-python312-flask30-sqlite-qodkd
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:8a:4f:2c:91
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-python312-flask30-sqlite-qodkd
+ ├───────── uuid: e00e7aca-962d-409c-87c2-c245ca08b54b
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://lingering-orangutan-840mmdvd.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-flask30-sqlite@sha256:bdb0bf35a9675b9b3836cbb626606da0606334d91768c7ba31195c3062d6f517
+ ├─────── memory: 768 MiB
+ ├────── service: lingering-orangutan-840mmdvd
+ ├─ private fqdn: httpserver-python312-flask30-sqlite-qodkd.internal
+ └─── private ip: 10.0.3.3
 ```
 
 In this case, the instance name is `httpserver-python312-flask30-sqlite-qodkd` and the address is `https://lingering-orangutan-840mmdvd.fra.unikraft.app`.
@@ -117,6 +127,7 @@ curl https://young-night-5fpf0jj8.fra.unikraft.app
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -128,6 +139,7 @@ fra    httpserver-python312-flask30-sqlite-qodkd  running  <my-org>/httpserver-p
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -139,12 +151,14 @@ httpserver-python312-flask30-sqlite-qodkd  lingering-orangutan-840mmdvd.fra.... 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-python312-flask30-sqlite-qodkd
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-python312-flask30-sqlite-qodkd
 ```
@@ -213,12 +227,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-python3.12-flask3.0/README.md
+++ b/httpserver-python3.12-flask3.0/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-python3.12-flask3.0/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-python3.12-flask3.0/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312-flask30:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python312-flask30:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-python312-flask30-bxwxm
- ├───────── uuid: 3ff1ebad-2639-4214-bab4-ed35c4c32fa4
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://damp-sunset-azd6dtyt.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-flask30@sha256:d6c8e4c5a4f44e1d642d8eaeaa1d820b2841194dd6c5d4a872ae0a895c767da9
- ├─────── memory: 512 MiB
- ├────── service: damp-sunset-azd6dtyt
- ├─ private fqdn: httpserver-python312-flask30-bxwxm.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-python312-flask30-bxwxm
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-python312-flask30-bxwxm
+ ├───────── uuid: 3ff1ebad-2639-4214-bab4-ed35c4c32fa4
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://damp-sunset-azd6dtyt.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312-flask30@sha256:d6c8e4c5a4f44e1d642d8eaeaa1d820b2841194dd6c5d4a872ae0a895c767da9
+ ├─────── memory: 512 MiB
+ ├────── service: damp-sunset-azd6dtyt
+ ├─ private fqdn: httpserver-python312-flask30-bxwxm.internal
+ └─── private ip: 10.0.6.5
+```
+
 In this case, the instance name is `httpserver-python312-flask30-bxwxm` and the address is `https://damp-sunset-azd6dtyt.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-python312-flask30-bxwxm  running  <my-org>/httpserver-python31
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-python312-flask30-bxwxm  damp-sunset-azd6dtyt.fra.unikraft.app  runni
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-python312-flask30-bxwxm
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-python312-flask30-bxwxm
 ```
@@ -215,12 +229,14 @@ Similar actions apply to other `pip3`-based apps.
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-python3.12/README.md
+++ b/httpserver-python3.12/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-python3.12/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-python3.12/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python312:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-python312-ma2i9
- ├───────── uuid: e7389eee-9808-4152-b2ec-1f3c0541fd05
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://young-night-5fpf0jj8.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312@sha256:278cb8b14f9faf9c2702dddd8bfb6124912d82c11b4a2c6590b6e32fc4049472
- ├─────── memory: 512 MiB
- ├────── service: young-night-5fpf0jj8
- ├─ private fqdn: httpserver-python312-ma2i9.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-python312-ma2i9
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-python312-ma2i9
+ ├───────── uuid: e7389eee-9808-4152-b2ec-1f3c0541fd05
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://young-night-5fpf0jj8.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-python312@sha256:278cb8b14f9faf9c2702dddd8bfb6124912d82c11b4a2c6590b6e32fc4049472
+ ├─────── memory: 512 MiB
+ ├────── service: young-night-5fpf0jj8
+ ├─ private fqdn: httpserver-python312-ma2i9.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-python312-ma2i9` and the address is `https://young-night-5fpf0jj8.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-python312-ma2i9  running  <my-org>/httpserver-python312       
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-python312-ma2i9  young-night-5fpf0jj8.fra.unikraft.app  running  1 mi
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances remove httpserver-python312-ma2i9
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-python312-ma2i9
 ```
@@ -177,6 +191,7 @@ The [`httpserver-python3.12-flask3.0`](https://github.com/unikraft-cloud/example
 
 Run the command below to deploy the app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-python312-flask30:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/httpserver-python312-flask30:latest
@@ -184,6 +199,7 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
@@ -232,12 +248,14 @@ See also the [`httpserver-python3.12-django5.0`](https://github.com/unikraft-clo
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-ruby3.2/README.md
+++ b/httpserver-ruby3.2/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-ruby3.2/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-ruby3.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-ruby32:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-ruby32:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-ruby32-s6l8n
- ├───────── uuid: b1ebbbc0-5efa-476c-adb6-99866773245c
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://silent-resonance-1jtz5c66.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-ruby32@sha256:4cf3b341898e6ebff18ff2b68353ef872dded650c9d16a6f005a8fbe8a7cbb3d
- ├─────── memory: 256 MiB
- ├────── service: silent-resonance-1jtz5c66
- ├─ private fqdn: httpserver-ruby32-s6l8n.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-ruby32-s6l8n
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-ruby32-s6l8n
+ ├───────── uuid: b1ebbbc0-5efa-476c-adb6-99866773245c
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://silent-resonance-1jtz5c66.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-ruby32@sha256:4cf3b341898e6ebff18ff2b68353ef872dded650c9d16a6f005a8fbe8a7cbb3d
+ ├─────── memory: 256 MiB
+ ├────── service: silent-resonance-1jtz5c66
+ ├─ private fqdn: httpserver-ruby32-s6l8n.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-ruby32-s6l8n` and the address is `https://silent-resonance-1jtz5c66.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-ruby32-s6l8n  running  <my-org>/httpserver-ruby32        256Mi
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-ruby32-s6l8n  silent-resonance-1jtz5c66.fra.unikraft.app  running  12
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-ruby32-s6l8n
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-ruby32-s6l8n
 ```
@@ -152,12 +166,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-rust-trunkrs-leptos/README.md
+++ b/httpserver-rust-trunkrs-leptos/README.md
@@ -8,6 +8,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-rust-trunkrs-leptos/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-rust-trunkrs-leptos/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust-trunkrs-leptos:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust-trunkrs-leptos:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s --metro fra -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-rust-trunkrs-leptos-n2j7k
- ├───────── uuid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://cool-wind-by4hq7nm.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust-trunkrs-leptos@sha256:6b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c
- ├─────── memory: 256 MiB
- ├────── service: cool-wind-by4hq7nm
- ├─ private fqdn: httpserver-rust-trunkrs-leptos-n2j7k.internal
- └─── private ip: 10.0.2.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-rust-trunkrs-leptos-n2j7k
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-rust-trunkrs-leptos-n2j7k
+ ├───────── uuid: 7b8c9d0e-1f2a-3b4c-5d6e-7f8a9b0c1d2e
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://cool-wind-by4hq7nm.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust-trunkrs-leptos@sha256:6b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c
+ ├─────── memory: 256 MiB
+ ├────── service: cool-wind-by4hq7nm
+ ├─ private fqdn: httpserver-rust-trunkrs-leptos-n2j7k.internal
+ └─── private ip: 10.0.2.3
+```
+
 In this case, the instance name is `httpserver-rust-trunkrs-leptos-n2j7k` and the address is `https://cool-wind-by4hq7nm.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ trunk serve
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-rust-trunkrs-leptos-n2j7k  running  <my-org>/httpserver-rust-t
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-rust-trunkrs-leptos-n2j7k  cool-wind-by4hq7nm.fra.unikraft.app  runni
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -142,12 +156,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-rust1.75-tokio/README.md
+++ b/httpserver-rust1.75-tokio/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 1. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-rust1.75-tokio/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-rust1.75-tokio/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust175-tokio:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust175-tokio:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-rust175-tokio-6gxsp
- ├───────── uuid: d5719f64-0653-42d7-b2de-aa6dee0ce467
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://empty-dawn-3coedrce.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust175-tokio@sha256:0ce75912711aa2329232a2ca6c3ccb7a244b6d546fafc081f815c2fde8224856
- ├─────── memory: 256 MiB
- ├────── service: empty-dawn-3coedrce
- ├─ private fqdn: httpserver-rust175-tokio-6gxsp.internal
- └─── private ip: 10.0.6.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-rust175-tokio-6gxsp
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-rust175-tokio-6gxsp
+ ├───────── uuid: d5719f64-0653-42d7-b2de-aa6dee0ce467
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://empty-dawn-3coedrce.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust175-tokio@sha256:0ce75912711aa2329232a2ca6c3ccb7a244b6d546fafc081f815c2fde8224856
+ ├─────── memory: 256 MiB
+ ├────── service: empty-dawn-3coedrce
+ ├─ private fqdn: httpserver-rust175-tokio-6gxsp.internal
+ └─── private ip: 10.0.6.3
+```
+
 In this case, the instance name is `httpserver-rust175-tokio-6gxsp` and the address is `https://empty-dawn-3coedrce.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-rust175-tokio-6gxsp  running  <my-org>/httpserver-rust175-toki
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-rust175-tokio-6gxsp  empty-dawn-3coedrce.fra.unikraft.app  running  1
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-rust175-tokio-6gxsp
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-rust175-tokio-6gxsp
 ```
@@ -156,12 +170,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-rust1.88-actix-web4/README.md
+++ b/httpserver-rust1.88-actix-web4/README.md
@@ -8,6 +8,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 1. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-rust1.88-actix-web4/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-rust1.88-actix-web4/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust188-actix-web4:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust188-actix-web4:latest
@@ -40,28 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-rust188-actix-web4-3pj27
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://autumn-silence-wupu2nus.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust188-actix-web4@sha256:11723705230f0f4545d2be7e4867dc67b396870769e91f05e2fa6d9da94f9b59
- ├─────── memory: 256 MiB
- ├────── service: autumn-silence-wupu2nus
- ├─ private fqdn: httpserver-rust188-actix-web4-3pj27.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-rust188-actix-web4-3pj27
@@ -84,6 +77,23 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-rust188-actix-web4-3pj27
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://autumn-silence-wupu2nus.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust188-actix-web4@sha256:11723705230f0f4545d2be7e4867dc67b396870769e91f05e2fa6d9da94f9b59
+ ├─────── memory: 256 MiB
+ ├────── service: autumn-silence-wupu2nus
+ ├─ private fqdn: httpserver-rust188-actix-web4-3pj27.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `httpserver-rust188-actix-web4-3pj27` and the address is `https://autumn-silence-wupu2nus.fra.unikraft.app`.
 They're different for each run.
 
@@ -101,6 +111,7 @@ Hey there!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -112,6 +123,7 @@ fra    httpserver-rust188-actix-web4-3pj27  running  <my-org>/httpserver-rust188
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -123,12 +135,14 @@ httpserver-rust188-actix-web4-3pj27  autumn-silence-wupu2nus.fra.unikraft.app  r
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-rust188-actix-web4-3pj27
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-rust188-actix-web4-3pj27
 ```
@@ -157,12 +171,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-rust1.88-rocket0.5/README.md
+++ b/httpserver-rust1.88-rocket0.5/README.md
@@ -8,6 +8,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-rust1.88-rocket0.5/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-rust1.88-rocket0.5
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust188-rocket05:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/httpserver-rust188-rocket05:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-rust188-rocket05-tuwq3
- ├───────── uuid: b6fe13e4-93b7-402b-bdec-1bc4d81bc275
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://empty-bobo-n3htmpye.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust188-rocket05@sha256:23a7a6e155758e6e8f75e9570f0aec5fb744f08c1bad2454d7386367c5ea45d6
- ├─────── memory: 256 MiB
- ├────── service: empty-bobo-n3htmpye
- ├─ private fqdn: httpserver-rust188-rocket05-tuwq3.internal
- └─── private ip: 10.0.6.6
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-rust188-rocket05-tuwq3
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-rust188-rocket05-tuwq3
+ ├───────── uuid: b6fe13e4-93b7-402b-bdec-1bc4d81bc275
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://empty-bobo-n3htmpye.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust188-rocket05@sha256:23a7a6e155758e6e8f75e9570f0aec5fb744f08c1bad2454d7386367c5ea45d6
+ ├─────── memory: 256 MiB
+ ├────── service: empty-bobo-n3htmpye
+ ├─ private fqdn: httpserver-rust188-rocket05-tuwq3.internal
+ └─── private ip: 10.0.6.6
+```
+
 In this case, the instance name is `httpserver-rust188-rocket05-tuwq3` and the address is `https://empty-bobo-n3htmpye.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ curl https://empty-bobo-n3htmpye.fra.unikraft.app/wave/Rocketeer/100
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-rust188-rocket05-tuwq3  running  <my-org>/httpserver-rust188-r
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-rust188-rocket05-tuwq3  empty-bobo-n3htmpye.fra.unikraft.app  running
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-rust188-rocket05-tuwq3
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-rust188-rocket05-tuwq3
 ```
@@ -156,12 +170,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/httpserver-rust1.91/README.md
+++ b/httpserver-rust1.91/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/httpserver-rust1.91` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/httpserver-rust1.91/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/httpserver-rust191:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 384M --image <my-org>/httpserver-rust191:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 384Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: httpserver-rust191-pinzf
- ├───────── uuid: 8acb3d35-38ba-4929-81de-950340662c14
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://snowy-feather-k4pfgl8t.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust191@sha256:7725556f4db01037438c08d5f934eabe89f33c172b4ae6c7424b3286351619e9
- ├─────── memory: 384 MiB
- ├────── service: snowy-feather-k4pfgl8t
- ├─ private fqdn: httpserver-rust191-pinzf.internal
- └─── private ip: 10.0.2.53
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         httpserver-rust191-pinzf
@@ -85,6 +77,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: httpserver-rust191-pinzf
+ ├───────── uuid: 8acb3d35-38ba-4929-81de-950340662c14
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://snowy-feather-k4pfgl8t.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/httpserver-rust191@sha256:7725556f4db01037438c08d5f934eabe89f33c172b4ae6c7424b3286351619e9
+ ├─────── memory: 384 MiB
+ ├────── service: snowy-feather-k4pfgl8t
+ ├─ private fqdn: httpserver-rust191-pinzf.internal
+ └─── private ip: 10.0.2.53
+```
+
 In this case, the instance name is `httpserver-rust191-pinzf` and the address is `snowy-feather-k4pfgl8t.fra.unikraft.app`.
 They're different for each run.
 
@@ -100,6 +110,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -111,6 +122,7 @@ fra    httpserver-rust191-pinzf  standby  <my-org>/httpserver-rust191        384
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -122,12 +134,14 @@ httpserver-rust191-pinzf  snowy-feather-k4pfgl8t.fra.unikraft.app  standby  stan
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete httpserver-rust191-pinzf
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove httpserver-rust191-pinzf
 ```
@@ -136,12 +150,14 @@ kraft cloud instance remove httpserver-rust191-pinzf
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/hugo0.122/README.md
+++ b/hugo0.122/README.md
@@ -9,6 +9,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/hugo0.122/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/hugo0.122/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/hugo0122:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:1313/tls+http -m 512M --image <my-org>/hugo0122:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:131
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:1313/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: hugo0122-zpabu
- ├───────── uuid: dfc6e06c-76cc-4aa1-a053-c4eded0d2456
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://morning-rain-jikpfy3t.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/hugo0122@sha256:68d20fdb707076b1cd0f2848b17cc75670d8a92b740edb9417aeb8463fef7f19
- ├─────── memory: 512 MiB
- ├────── service: morning-rain-jikpfy3t
- ├─ private fqdn: hugo0122-zpabu.internal
- └─── private ip: 10.0.6.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         hugo0122-zpabu
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: hugo0122-zpabu
+ ├───────── uuid: dfc6e06c-76cc-4aa1-a053-c4eded0d2456
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://morning-rain-jikpfy3t.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/hugo0122@sha256:68d20fdb707076b1cd0f2848b17cc75670d8a92b740edb9417aeb8463fef7f19
+ ├─────── memory: 512 MiB
+ ├────── service: morning-rain-jikpfy3t
+ ├─ private fqdn: hugo0122-zpabu.internal
+ └─── private ip: 10.0.6.4
+```
+
 In this case, the instance name is `hugo0122-zpabu` and the address is `https://morning-rain-jikpfy3t.fra.unikraft.app`.
 They're different for each run.
 
@@ -106,6 +116,7 @@ curl https://morning-rain-jikpfy3t.fra.unikraft.app
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -117,6 +128,7 @@ fra    hugo0122-zpabu  running  <my-org>/hugo0122        512MiB  1      morning-
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -128,12 +140,14 @@ hugo0122-zpabu  morning-rain-jikpfy3t.fra.unikraft.app  running  1 minute ago  o
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete hugo0122-zpabu
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove hugo0122-zpabu
 ```
@@ -156,12 +170,14 @@ Tools like [`Jekyll`](https://jekyllrb.com/) or [`Hugo`](https://gohugo.io/) can
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/imaginary/README.md
+++ b/imaginary/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/imaginary/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/imaginary/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/imaginary:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/imaginary:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: imaginary-mwb4y
- ├───────── uuid: 8cf18bf7-2bf6-4f23-be07-f9c234c7962d
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://divine-wind-1ycjvhqs.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/imaginary@sha256:673834bc531038bb621266f7fd635a04e559050cbe82876df811fd4b975ea4fe
- ├─────── memory: 512 MiB
- ├────── service: divine-wind-1ycjvhqs
- ├─ private fqdn: imaginary-mwb4y.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         imaginary-mwb4y
@@ -84,6 +76,24 @@ networks:
   mac:        12:b0:e2:ed:95:49
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: imaginary-mwb4y
+ ├───────── uuid: 8cf18bf7-2bf6-4f23-be07-f9c234c7962d
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://divine-wind-1ycjvhqs.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/imaginary@sha256:673834bc531038bb621266f7fd635a04e559050cbe82876df811fd4b975ea4fe
+ ├─────── memory: 512 MiB
+ ├────── service: divine-wind-1ycjvhqs
+ ├─ private fqdn: imaginary-mwb4y.internal
+ └─── private ip: 10.0.3.3
 ```
 
 In this case, the instance name is `imaginary-mwb4y` and the address is `https://divine-wind-1ycjvhqs.fra.unikraft.app`.
@@ -119,6 +129,7 @@ The API provides endpoints, together with parameters, for different image proces
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -130,6 +141,7 @@ fra    imaginary-mwb4y  running  <my-org>/imaginary        512MiB  1      divine
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -141,12 +153,14 @@ imaginary-mwb4y  divine-wind-1ycjvhqs.fra.unikraft.app  running  54 seconds ago 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete imaginary-mwb4y
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove imaginary-mwb4y
 ```
@@ -168,12 +182,14 @@ You can update the `cmd` line with [command line option for Imaginary](https://g
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -8,6 +8,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/mariadb/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/mariadb
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mariadb:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 3306:3306/tls -m 1G -e MARIADB_ROOT_PASSWORD="unikraft" --image <my-org>/mariadb:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 3306:3306/tls -M 1Gi --env MARIADB_ROOT_PASSWORD="unikraft" .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: mariadb-w2g2z
- ├───────── uuid: ba696c22-adff-4fba-88b9-d1b790ca2357
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://twilight-sun-82lt4ddk.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/mariadb@sha256:6e31d28b351eb12a070e3074f0a500532d0a494332947e9d8dbfa093d2d551fd
- ├─────── memory: 1024 MiB
- ├────── service: twilight-sun-82lt4ddk
- ├─ private fqdn: mariadb-w2g2z.internal
- └─── private ip: 10.0.6.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         mariadb-w2g2z
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:ee:29:71:e4
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: mariadb-w2g2z
+ ├───────── uuid: ba696c22-adff-4fba-88b9-d1b790ca2357
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://twilight-sun-82lt4ddk.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/mariadb@sha256:6e31d28b351eb12a070e3074f0a500532d0a494332947e9d8dbfa093d2d551fd
+ ├─────── memory: 1024 MiB
+ ├────── service: twilight-sun-82lt4ddk
+ ├─ private fqdn: mariadb-w2g2z.internal
+ └─── private ip: 10.0.6.3
 ```
 
 In this case, the instance name is `mariadb-w2g2z` which is different for each run.
@@ -122,6 +132,7 @@ To disconnect, kill the `socat` command using `Ctrl+c`.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -133,6 +144,7 @@ fra    mariadb-w2g2z  running  <my-org>/mariadb        1024MiB  1      twilight-
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -144,12 +156,14 @@ mariadb-w2g2z  twilight-sun-82lt4ddk.fra.unikraft.app  running  1 minute ago  oc
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instance remove mariadb-w2g2z
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove mariadb-w2g2z
 ```
@@ -162,18 +176,21 @@ kraft cloud instance remove mariadb-w2g2z
 You can use [volumes](https://unikraft.com/docs/platform/volumes) for data persistence for your MariaDB instance.
 For that you would first create a volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume create --set metro=fra --set name=mariadb-store --set size=512M
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume create --name mariadb-store --size 512Mi
 ```
 
 Then start the MariaDB instance and mount that volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mariadb:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 3306:3306/tls -m 1G -e MARIADB_ROOT_PASSWORD="unikraft" --volume mariadb-store:/var/lib --image <my-org>/mariadb:latest
@@ -181,6 +198,7 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -M 1Gi -p 3306:3306/tls --env MARIADB_ROOT_PASSWORD="unikraft" --volume mariadb-store:/var/lib .
 ```
@@ -196,12 +214,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/mcp-server-arxiv/README.md
+++ b/mcp-server-arxiv/README.md
@@ -21,6 +21,10 @@ To run this MCP server on Unikraft Cloud:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 1. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/mcp-server-arxiv/` directory:
 
 ```bash
@@ -31,12 +35,14 @@ cd examples/mcp-server-arxiv/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -46,6 +52,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mcp-server-arxiv:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 2G --image <my-org>/mcp-server-arxiv:latest
@@ -53,29 +60,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 2Gi .
 ```
 
 The output shows your instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: mcp-server-arxiv-l7l24
- ├───────── uuid: 1a721bb8-4472-4149-9870-789b1df5f80a
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://billowing-breeze-nuusy7l2.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/mcp-server-arxiv@sha256:ea1e677ccc03628a3e7d57a4cd41118e3d2a631bcb2c34203bb9b175e7977f00
- ├─────── memory: 2048 MiB
- ├────── service: billowing-breeze-nuusy7l2
- ├─ private fqdn: mcp-server-arxiv-l7l24.internal
- └─── private ip: 10.0.1.149
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         mcp-server-arxiv-l7l24
@@ -96,6 +88,24 @@ networks:
   mac:        12:b0:26:13:a0:89
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: mcp-server-arxiv-l7l24
+ ├───────── uuid: 1a721bb8-4472-4149-9870-789b1df5f80a
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://billowing-breeze-nuusy7l2.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/mcp-server-arxiv@sha256:ea1e677ccc03628a3e7d57a4cd41118e3d2a631bcb2c34203bb9b175e7977f00
+ ├─────── memory: 2048 MiB
+ ├────── service: billowing-breeze-nuusy7l2
+ ├─ private fqdn: mcp-server-arxiv-l7l24.internal
+ └─── private ip: 10.0.1.149
 ```
 
 In this case, the instance name is `mcp-server-arxiv-l7l24` and the service `billowing-breeze-nuusy7l2`.
@@ -120,6 +130,7 @@ Description: Search for papers on arXiv with advanced filtering and query optimi
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -131,6 +142,7 @@ fra    mcp-server-arxiv-l7l24  standby  <my-org>/mcp-server-arxiv        2.0GiB 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -151,18 +163,21 @@ kraft cloud instance remove mcp-server-arxiv-l7l24
 You can use [volumes](https://unikraft.com/docs/platform/volumes) for data persistence.
 For that you would first create a volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume create --set metro=fra --set name=mcp-server-arxiv-data --set size=500M
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume create --name mcp-server-arxiv-data --size 500Mi
 ```
 
 Then start the MCP server instance and mount that volume (while specifying the storage path):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mcp-server-arxiv:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -v mcp-server-arxiv-data:/volume -p 443:8080/tls+http -m 2G --image <my-org>/mcp-server-arxiv:latest -- "/usr/local/bin/python /src/server.py --storage-path /volume"
@@ -170,6 +185,7 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -v mcp-server-arxiv-data:/volume -p 443:8080/tls+http -M 2Gi . --entrypoint "/usr/local/bin/python /src/server.py --storage-path /volume"
 ```
@@ -193,12 +209,14 @@ The ArXiv MCP Server provides the following tools:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/mcp-server-simple/README.md
+++ b/mcp-server-simple/README.md
@@ -13,6 +13,10 @@ To run this MCP server on Unikraft Cloud:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 1. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/mcp-server-simple/` directory:
 
 ```bash
@@ -23,12 +27,14 @@ cd examples/mcp-server-simple/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -38,6 +44,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mcp-server-simple:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/mcp-server-simple:latest
@@ -45,29 +52,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows your instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: mcp-server-simple-bbdcb
- ├───────── uuid: e87d3591-3497-4f30-bd76-1dc886059647
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://cool-paper-b6mht7jv.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/mcp-server-simple@sha256:cbbfb441ee313a6c7c0de571e9002f0f6031312e203ffb6be3b8f4950df3bc20
- ├─────── memory: 512 MiB
- ├────── service: cool-paper-b6mht7jv
- ├─ private fqdn: mcp-server-simple-bbdcb.internal
- └─── private ip: 10.0.0.193
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         mcp-server-simple-bbdcb
@@ -88,6 +80,24 @@ networks:
   mac:        12:b0:39:2b:a3:15
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: mcp-server-simple-bbdcb
+ ├───────── uuid: e87d3591-3497-4f30-bd76-1dc886059647
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://cool-paper-b6mht7jv.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/mcp-server-simple@sha256:cbbfb441ee313a6c7c0de571e9002f0f6031312e203ffb6be3b8f4950df3bc20
+ ├─────── memory: 512 MiB
+ ├────── service: cool-paper-b6mht7jv
+ ├─ private fqdn: mcp-server-simple-bbdcb.internal
+ └─── private ip: 10.0.0.193
 ```
 
 In this case, the instance name is `mcp-server-simple-bbdcb` and the service `cool-paper-b6mht7jv`.
@@ -121,6 +131,7 @@ Description: Get current time in a timezone.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -132,6 +143,7 @@ fra    mcp-server-simple-bbdcb  standby  <my-org>/mcp-server-simple        512Mi
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -226,12 +238,14 @@ This provides:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/memcached1.6/README.md
+++ b/memcached1.6/README.md
@@ -10,6 +10,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/memcached1.6/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/memcached1.6/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/memcached16:latest
 unikraft run --scale-to-zero policy=off --metro fra -p 11211:11211/tls -m 256M --image <my-org>/memcached16:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=off --metro fra -p 11211:11211/tls -m 256M -
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero off -p 11211:11211/tls -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: memcached16-arkv7
- ├───────── uuid: da436eca-bc64-46d7-a04c-72832652b10e
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://weathered-smoke-hehsdinv.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/memcached16@sha256:f53cdbce4dc185e8acc8ecb93a0ab0ba99085ca0837a0ad2062aae9e31382e58
- ├─────── memory: 256 MiB
- ├────── service: weathered-smoke-hehsdinv
- ├─ private fqdn: memcached16-arkv7.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         memcached16-arkv7
@@ -85,6 +77,24 @@ networks:
   mac:        12:b0:e3:15:81:6b
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: memcached16-arkv7
+ ├───────── uuid: da436eca-bc64-46d7-a04c-72832652b10e
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://weathered-smoke-hehsdinv.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/memcached16@sha256:f53cdbce4dc185e8acc8ecb93a0ab0ba99085ca0837a0ad2062aae9e31382e58
+ ├─────── memory: 256 MiB
+ ├────── service: weathered-smoke-hehsdinv
+ ├─ private fqdn: memcached16-arkv7.internal
+ └─── private ip: 10.0.6.5
 ```
 
 In this case, the instance name is `memcached16-arkv7` which is different for each run.
@@ -125,6 +135,7 @@ To disconnect, kill the `socat` command with ctrl-C.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -136,6 +147,7 @@ fra    memcached16-arkv7  running  <my-org>/memcached16        256MiB  1      we
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -147,12 +159,14 @@ memcached16-arkv7  weathered-smoke-hehsdinv.fra.unikraft.app  running  11 minute
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete memcached16-arkv7
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove memcached16-arkv7
 ```
@@ -168,12 +182,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/minio/README.md
+++ b/minio/README.md
@@ -10,6 +10,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/minio/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/minio/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/minio:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:9001/tls+http -p 9000:9000/tls -m 512M --image <my-org>/minio:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:900
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:9001/tls+http -p 9000:9000/tls -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: minio-w2my8
- ├───────── uuid: 31e691ad-05a0-48b6-ad49-7f79da8e1754
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://icy-bird-tregaga9.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/minio@sha256:ba4657c607495326b0e29b512fb33a4179cd1b2a15fbfdd3ccc6e66209a701dd
- ├─────── memory: 512 MiB
- ├────── service: icy-bird-tregaga9
- ├─ private fqdn: minio-w2my8.internal
- └─── private ip: 10.0.6.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         minio-w2my8
@@ -87,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: minio-w2my8
+ ├───────── uuid: 31e691ad-05a0-48b6-ad49-7f79da8e1754
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://icy-bird-tregaga9.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/minio@sha256:ba4657c607495326b0e29b512fb33a4179cd1b2a15fbfdd3ccc6e66209a701dd
+ ├─────── memory: 512 MiB
+ ├────── service: icy-bird-tregaga9
+ ├─ private fqdn: minio-w2my8.internal
+ └─── private ip: 10.0.6.4
+```
+
 In this case, the instance name is `minio-w2my8` and the address is `https://icy-bird-tregaga9.fra.unikraft.app`.
 They're different for each run.
 
@@ -95,6 +105,7 @@ The default account/password are `minioadmin/minioadmin`.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -106,6 +117,7 @@ fra    minio-w2my8  running  <my-org>/minio        512MiB  1      icy-bird-trega
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -117,12 +129,14 @@ minio-w2my8  icy-bird-tregaga9.fra.unikraft.app  running  1 minute ago  oci://un
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete minio-w2my8
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove minio-w2my8
 ```
@@ -138,12 +152,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -9,6 +9,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/mongodb/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/mongodb/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mongodb:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 27017:27017/tls -m 1G --image <my-org>/mongodb:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 27017:27017/tls -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: mongodb-6tiuu
- ├───────── uuid: 99779597-0bdb-4160-b902-a160c3ab4b2a
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://bold-brook-khkwv7of.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/mongodb@sha256:e6ff5153f106e2d5e2a10881818cd1b90fe3ff1294ad80879b2239ffc52aff0e
- ├─────── memory: 1024 MiB
- ├────── service: bold-brook-khkwv7of
- ├─ private fqdn: mongodb-6tiuu.internal
- └─── private ip: 10.0.6.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         mongodb-6tiuu
@@ -84,6 +76,24 @@ networks:
   mac:        12:b0:d7:7b:83:97
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: mongodb-6tiuu
+ ├───────── uuid: 99779597-0bdb-4160-b902-a160c3ab4b2a
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://bold-brook-khkwv7of.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/mongodb@sha256:e6ff5153f106e2d5e2a10881818cd1b90fe3ff1294ad80879b2239ffc52aff0e
+ ├─────── memory: 1024 MiB
+ ├────── service: bold-brook-khkwv7of
+ ├─ private fqdn: mongodb-6tiuu.internal
+ └─── private ip: 10.0.6.4
 ```
 
 In this case, the instance name is `mongodb-6tiuu` and the the address is
@@ -112,6 +122,7 @@ test>
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -123,6 +134,7 @@ fra    mongodb-6tiuu  running  <my-org>/mongodb        1.0GiB  1      bold-brook
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -134,12 +146,14 @@ mongodb-6tiuu  bold-brook-khkwv7of.fra.unikraft.app  running  20 minutes ago  oc
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete mongodb-6tiuu
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove mongodb-6tiuu
 ```
@@ -149,18 +163,21 @@ kraft cloud instance remove mongodb-6tiuu
 You can use [volumes](https://unikraft.com/docs/platform/volumes) for data persistence for your MongoDB instance.
 For that you would first create a volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume create --set metro=fra --set name=mongodb-store --set size=512M
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume create --name mongodb-store --size 512Mi
 ```
 
 Then start the MongoDB instance and mount that volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/mongodb:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 27017:27017/tls -m 1G --volume mongodb-store:/data/db --image <my-org>/mongodb:latest
@@ -168,6 +185,7 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -M 1Gi -p 27017:27017/tls --volume mongodb-store:/data/db .
 ```
@@ -183,12 +201,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/nginx/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/nginx/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/nginx:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 256M --image <my-org>/nginx:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: nginx-67zbu
- ├───────── uuid: 8a8bc1b9-0af6-420e-a426-190dc2da9eaa
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://nameless-fog-0tvh1uov.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/nginx@sha256:f51ecc121c9ca34abb88a2bc6a69765501304f7893f7e85af15fbec3dc86e2bd
- ├─────── memory: 256 MiB
- ├────── service: nameless-fog-0tvh1uov
- ├─ private fqdn: nginx-67zbu.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         nginx-67zbu
@@ -87,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: nginx-67zbu
+ ├───────── uuid: 8a8bc1b9-0af6-420e-a426-190dc2da9eaa
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://nameless-fog-0tvh1uov.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/nginx@sha256:f51ecc121c9ca34abb88a2bc6a69765501304f7893f7e85af15fbec3dc86e2bd
+ ├─────── memory: 256 MiB
+ ├────── service: nameless-fog-0tvh1uov
+ ├─ private fqdn: nginx-67zbu.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `nginx-67zbu` and the address is `https://nameless-fog-0tvh1uov.fra.unikraft.app`.
 They're different for each run.
 
@@ -106,6 +116,7 @@ curl https://nameless-fog-0tvh1uov.fra.unikraft.app
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -117,6 +128,7 @@ fra    nginx-67zbu  running  <my-org>/nginx        256MiB  1      nameless-fog-0
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -128,12 +140,14 @@ nginx-67zbu  nameless-fog-0tvh1uov.fra.unikraft.app  running  5 minutes ago  oci
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete nginx-67zbu
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove nginx-67zbu
 ```
@@ -172,12 +186,14 @@ You can set a new webroot (different than `wwwroot`), or a different internal po
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node-code-execution/README.md
+++ b/node-code-execution/README.md
@@ -20,12 +20,14 @@ cd examples/node-code-execution/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -38,12 +40,14 @@ export UKC_METRO=fra
 
 First, package and push the base Node.js image (see `server.ts` for the runtime implementation):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-code-exec:latest
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft pkg \
    --name index.unikraft.io/<my-org>/node-code-exec:latest \
@@ -61,6 +65,7 @@ There is a little tweak—right before loading the ROM code and starting the ser
 
 Create an instance that uses the base Node.js image without any ROM attached:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft run --metro fra \
   --name node-exec \
@@ -70,6 +75,7 @@ unikraft run --metro fra \
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance create \
   --start \
@@ -80,21 +86,7 @@ kraft cloud instance create \
 
 The output shows the instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node-exec
- ├───────── uuid: 96608ed2-45e0-4c8f-8269-5d8cd3e4b41a
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├──────── image: oci://unikraft.io/<my-org>/node-code-exec@sha256:71487fd6196987cf65fb89eb84405cb796677aba177dabacf391f09618313328
- ├─────── memory: 512 MiB
- ├─ private fqdn: node-exec.internal
- └─── private ip: 10.0.5.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node-exec
@@ -112,13 +104,31 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node-exec
+ ├───────── uuid: 96608ed2-45e0-4c8f-8269-5d8cd3e4b41a
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├──────── image: oci://unikraft.io/<my-org>/node-code-exec@sha256:71487fd6196987cf65fb89eb84405cb796677aba177dabacf391f09618313328
+ ├─────── memory: 512 MiB
+ ├─ private fqdn: node-exec.internal
+ └─── private ip: 10.0.5.4
+```
+
 This instance is short-lived, since right before the server starts, it triggers a conversion into a template.
 To check that the template is ready, run:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances templates list
 ```
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 METRO  NAME       STATE     IMAGE                    ARGS  MEMORY  VCPUS  CREATED
 fra    node-exec  template  <my-org>/node-code-exec        512MiB  1      5 seconds ago
@@ -126,10 +136,12 @@ fra    node-exec  template  <my-org>/node-code-exec        512MiB  1      5 seco
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance template list
 ```
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 NAME       IMAGE                                                                                                              ARGS  CREATED AT
 node-exec  oci://unikraft.io/<my-org>/node-code-exec@sha256:71487fd6196987cf65fb89eb84405cb796677aba177dabacf391f09618313328        5 seconds ago
@@ -139,6 +151,7 @@ node-exec  oci://unikraft.io/<my-org>/node-code-exec@sha256:71487fd6196987cf65fb
 
 Create and push the ROMs with the code (see `rom1/fs/rom.js` and `rom2/fs/rom.ts`):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build rom1/ --output <my-org>/node-rom1:latest
 unikraft build rom2/ --output <my-org>/node-rom2:latest
@@ -146,6 +159,7 @@ unikraft build rom2/ --output <my-org>/node-rom2:latest
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft pkg \
    --rom ./fs \
@@ -169,6 +183,7 @@ kraft pkg \
 
 Create a new instance from the template, attaching the first ROM:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft run --metro fra \
   --name node-exec-rom1 \
@@ -180,6 +195,7 @@ unikraft run --metro fra \
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # kraft does not support creating instances with attached ROMs, but you can use the API directly
 curl -X POST "$UKC_METRO/instances" \
@@ -218,6 +234,7 @@ curl -X POST "$UKC_METRO/instances" \
 
 Create another instance from the same template, but with the second ROM attached:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft run --metro fra \
   --name node-exec-rom2 \
@@ -229,6 +246,7 @@ unikraft run --metro fra \
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # kraft does not support creating instances with attached ROMs, but you can use the API directly
 curl -X POST "$UKC_METRO/instances" \
@@ -267,6 +285,7 @@ curl -X POST "$UKC_METRO/instances" \
 
 List the instances and note their FQDN values:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -279,6 +298,7 @@ fra    node-exec-rom1  standby  <my-org>/node-code-exec        512MiB  1      sp
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -305,12 +325,14 @@ Auf Wiedersehen!
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node-playwright-chromium/README.md
+++ b/node-playwright-chromium/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node-playwright-chromium/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/node-playwright-chromium/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-playwright-chromium:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/node-playwright-chromium:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node-playwright-chromium-v5f8p
- ├───────── uuid: a1b2c3d4-e5f6-7a8b-9c0d-a1b2c3d4e5f6
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://gentle-moon-cx2jh5wd.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node-playwright-chromium@sha256:7c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d
- ├─────── memory: 4096 MiB
- ├────── service: gentle-moon-cx2jh5wd
- ├─ private fqdn: node-playwright-chromium-v5f8p.internal
- └─── private ip: 10.0.4.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node-playwright-chromium-v5f8p
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node-playwright-chromium-v5f8p
+ ├───────── uuid: a1b2c3d4-e5f6-7a8b-9c0d-a1b2c3d4e5f6
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://gentle-moon-cx2jh5wd.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node-playwright-chromium@sha256:7c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d
+ ├─────── memory: 4096 MiB
+ ├────── service: gentle-moon-cx2jh5wd
+ ├─ private fqdn: node-playwright-chromium-v5f8p.internal
+ └─── private ip: 10.0.4.3
+```
+
 In this case, the instance name is `node-playwright-chromium-v5f8p` and the address is `https://gentle-moon-cx2jh5wd.fra.unikraft.app`.
 They're different for each run.
 
@@ -102,6 +112,7 @@ curl "https://<NAME>.<METRO>.unikraft.app/?page=https://bing.com" -o ss-bing.png
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -113,6 +124,7 @@ fra    node-playwright-chromium-v5f8p  running  <my-org>/node-playwright-chromiu
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,12 +136,14 @@ node-playwright-chromium-v5f8p  gentle-moon-cx2jh5wd.fra.unikraft.app  running  
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -144,12 +158,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node-playwright-firefox/README.md
+++ b/node-playwright-firefox/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node-playwright-firefox/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/node-playwright-firefox/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-playwright-firefox:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/node-playwright-firefox:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node-playwright-firefox-q3m9k
- ├───────── uuid: d4e5f6a7-b8c9-0d1e-2f3a-d4e5f6a7b8c9
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://bright-lake-dh6xp2sq.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node-playwright-firefox@sha256:8d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e
- ├─────── memory: 4096 MiB
- ├────── service: bright-lake-dh6xp2sq
- ├─ private fqdn: node-playwright-firefox-q3m9k.internal
- └─── private ip: 10.0.5.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node-playwright-firefox-q3m9k
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node-playwright-firefox-q3m9k
+ ├───────── uuid: d4e5f6a7-b8c9-0d1e-2f3a-d4e5f6a7b8c9
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://bright-lake-dh6xp2sq.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node-playwright-firefox@sha256:8d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e
+ ├─────── memory: 4096 MiB
+ ├────── service: bright-lake-dh6xp2sq
+ ├─ private fqdn: node-playwright-firefox-q3m9k.internal
+ └─── private ip: 10.0.5.3
+```
+
 In this case, the instance name is `node-playwright-firefox-q3m9k` and the address is `https://bright-lake-dh6xp2sq.fra.unikraft.app`.
 They're different for each run.
 
@@ -102,6 +112,7 @@ curl "https://<NAME>.<METRO>.unikraft.app/?page=https://bing.com" -o ss-bing.png
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -113,6 +124,7 @@ fra    node-playwright-firefox-q3m9k  running  <my-org>/node-playwright-firefox 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,12 +136,14 @@ node-playwright-firefox-q3m9k  bright-lake-dh6xp2sq.fra.unikraft.app  running  1
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -144,12 +158,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node-playwright-webkit/README.md
+++ b/node-playwright-webkit/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node-playwright-webkit/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/node-playwright-webkit/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node-playwright-webkit:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/node-playwright-webkit:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node-playwright-webkit-t7r2j
- ├───────── uuid: a2b3c4d5-e6f7-8a9b-0c1d-a2b3c4d5e6f7
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://silent-fog-er8np3fb.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node-playwright-webkit@sha256:9e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f
- ├─────── memory: 4096 MiB
- ├────── service: silent-fog-er8np3fb
- ├─ private fqdn: node-playwright-webkit-t7r2j.internal
- └─── private ip: 10.0.6.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node-playwright-webkit-t7r2j
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node-playwright-webkit-t7r2j
+ ├───────── uuid: a2b3c4d5-e6f7-8a9b-0c1d-a2b3c4d5e6f7
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://silent-fog-er8np3fb.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node-playwright-webkit@sha256:9e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f
+ ├─────── memory: 4096 MiB
+ ├────── service: silent-fog-er8np3fb
+ ├─ private fqdn: node-playwright-webkit-t7r2j.internal
+ └─── private ip: 10.0.6.4
+```
+
 In this case, the instance name is `node-playwright-webkit-t7r2j` and the address is `https://silent-fog-er8np3fb.fra.unikraft.app`.
 They're different for each run.
 
@@ -102,6 +112,7 @@ curl "https://<NAME>.<METRO>.unikraft.app/?page=https://bing.com" -o ss-bing.png
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -113,6 +124,7 @@ fra    node-playwright-webkit-t7r2j  running  <my-org>/node-playwright-webkit   
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,12 +136,14 @@ node-playwright-webkit-t7r2j  silent-fog-er8np3fb.fra.unikraft.app  running  1 m
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -144,12 +158,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node18-agario/README.md
+++ b/node18-agario/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node18-agario/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/node18-agario/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node18-agario:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro fra -p 443:3000/tls+http -m 1G --image <my-org>/node18-agario:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 2s --metro fra -p 443:3000/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node18-agario-5k2xp
- ├───────── uuid: b3c4d5e6-f7a8-9b0c-1d2e-b3c4d5e6f7a8
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://dark-meadow-fj9tm6bq.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node18-agario@sha256:0f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a
- ├─────── memory: 1024 MiB
- ├────── service: dark-meadow-fj9tm6bq
- ├─ private fqdn: node18-agario-5k2xp.internal
- └─── private ip: 10.0.3.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node18-agario-5k2xp
@@ -87,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node18-agario-5k2xp
+ ├───────── uuid: b3c4d5e6-f7a8-9b0c-1d2e-b3c4d5e6f7a8
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://dark-meadow-fj9tm6bq.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node18-agario@sha256:0f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a
+ ├─────── memory: 1024 MiB
+ ├────── service: dark-meadow-fj9tm6bq
+ ├─ private fqdn: node18-agario-5k2xp.internal
+ └─── private ip: 10.0.3.5
+```
+
 In this case, the instance name is `node18-agario-5k2xp` and the address is `https://dark-meadow-fj9tm6bq.fra.unikraft.app`.
 They're different for each run.
 
@@ -96,6 +106,7 @@ After deploying, you can query the service using the provided URL.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -107,6 +118,7 @@ fra    node18-agario-5k2xp  running  <my-org>/node18-agario        1024MiB  1   
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -118,12 +130,14 @@ node18-agario-5k2xp  dark-meadow-fj9tm6bq.fra.unikraft.app  running  1 minute ag
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -138,12 +152,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node18-wingsio/README.md
+++ b/node18-wingsio/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node18-wingsio/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/node18-wingsio/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node18-wingsio:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1500,stateful=true --metro fra -p 443:3000/tls+http -m 1G --image <my-org>/node18-wingsio:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1500,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1500ms --metro fra -p 443:3000/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node18-wingsio-h4n8m
- ├───────── uuid: c4d5e6f7-a8b9-0c1d-2e3f-c4d5e6f7a8b9
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://swift-cloud-gk7us4cz.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node18-wingsio@sha256:1a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b
- ├─────── memory: 1024 MiB
- ├────── service: swift-cloud-gk7us4cz
- ├─ private fqdn: node18-wingsio-h4n8m.internal
- └─── private ip: 10.0.4.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node18-wingsio-h4n8m
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node18-wingsio-h4n8m
+ ├───────── uuid: c4d5e6f7-a8b9-0c1d-2e3f-c4d5e6f7a8b9
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://swift-cloud-gk7us4cz.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node18-wingsio@sha256:1a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b
+ ├─────── memory: 1024 MiB
+ ├────── service: swift-cloud-gk7us4cz
+ ├─ private fqdn: node18-wingsio-h4n8m.internal
+ └─── private ip: 10.0.4.4
+```
+
 In this case, the instance name is `node18-wingsio-h4n8m` and the address is `https://swift-cloud-gk7us4cz.fra.unikraft.app`.
 They're different for each run.
 
@@ -95,6 +105,7 @@ After deploying, you can query the service using the provided URL.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -106,6 +117,7 @@ fra    node18-wingsio-h4n8m  running  <my-org>/node18-wingsio        1024MiB  1 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -117,12 +129,14 @@ node18-wingsio-h4n8m  swift-cloud-gk7us4cz.fra.unikraft.app  running  1 minute a
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -137,12 +151,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node21-websocket/README.md
+++ b/node21-websocket/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node21-websocket/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/node21-websocket/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node21-websocket:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 1G --image <my-org>/node21-websocket:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s --metro fra -p 443:8080/tls+http -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node21-websocket-j2x9r
- ├───────── uuid: d5e6f7a8-b9c0-1d2e-3f4a-d5e6f7a8b9c0
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://lively-breeze-hp3wx6yt.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node21-websocket@sha256:2b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c
- ├─────── memory: 1024 MiB
- ├────── service: lively-breeze-hp3wx6yt
- ├─ private fqdn: node21-websocket-j2x9r.internal
- └─── private ip: 10.0.5.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node21-websocket-j2x9r
@@ -85,6 +77,24 @@ networks:
   mac:        12:b0:d3:af:12:0c
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node21-websocket-j2x9r
+ ├───────── uuid: d5e6f7a8-b9c0-1d2e-3f4a-d5e6f7a8b9c0
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://lively-breeze-hp3wx6yt.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node21-websocket@sha256:2b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c
+ ├─────── memory: 1024 MiB
+ ├────── service: lively-breeze-hp3wx6yt
+ ├─ private fqdn: node21-websocket-j2x9r.internal
+ └─── private ip: 10.0.5.4
 ```
 
 In this case, the instance name is `node21-websocket-j2x9r` and the address is `https://lively-breeze-hp3wx6yt.fra.unikraft.app`.
@@ -109,6 +119,7 @@ Then enter messages, that will be replied by the server.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -120,6 +131,7 @@ fra    node21-websocket-j2x9r  running  <my-org>/node21-websocket        1024MiB
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -131,12 +143,14 @@ node21-websocket-j2x9r  lively-breeze-hp3wx6yt.fra.unikraft.app  running  1 minu
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -152,12 +166,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/node24-karaoke/README.md
+++ b/node24-karaoke/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/node24-karaoke` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/node24-karaoke/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/node24-karaoke:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro fra -p 443:8080/tls+http -m 2G --image <my-org>/node24-karaoke:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=2000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 2s -p 443:8080/tls+http -M 2Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: node24-karaoke-9lw5q
- ├───────── uuid: e5f6a7b8-c9d0-1234-efab-345678901234
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://wild-song-p5q2nrwx.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/node24-karaoke@sha256:1a3c5e7b9d2f4a6c8e0b2d4f6a8c0e2b4d6f8a0b2c4e6f8a0b2d4f6a8c0e2b
- ├─────── memory: 2 GiB
- ├────── service: wild-song-p5q2nrwx
- ├─ private fqdn: node24-karaoke-9lw5q.internal
- └─── private ip: 10.0.3.8
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         node24-karaoke-9lw5q
@@ -84,6 +76,24 @@ networks:
   mac:        12:b0:30:64:22:f9
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: node24-karaoke-9lw5q
+ ├───────── uuid: e5f6a7b8-c9d0-1234-efab-345678901234
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://wild-song-p5q2nrwx.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/node24-karaoke@sha256:1a3c5e7b9d2f4a6c8e0b2d4f6a8c0e2b4d6f8a0b2c4e6f8a0b2d4f6a8c0e2b
+ ├─────── memory: 2 GiB
+ ├────── service: wild-song-p5q2nrwx
+ ├─ private fqdn: node24-karaoke-9lw5q.internal
+ └─── private ip: 10.0.3.8
 ```
 
 In this case, the instance name is `node24-karaoke-9lw5q` and the address is `https://wild-song-p5q2nrwx.fra.unikraft.app`.
@@ -111,6 +121,7 @@ curl https://wild-song-p5q2nrwx.fra.unikraft.app
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -122,6 +133,7 @@ fra    node24-karaoke-9lw5q  running  <my-org>/node24-karaoke        2GiB    1  
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -133,12 +145,14 @@ node24-karaoke-9lw5q  wild-song-p5q2nrwx.fra.unikraft.app  running  since 3mins 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete node24-karaoke-9lw5q
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove node24-karaoke-9lw5q
 ```
@@ -192,12 +206,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/novnc-browser/README.md
+++ b/novnc-browser/README.md
@@ -12,6 +12,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/novnc-browser` directory:
 
 ```bash
@@ -22,12 +26,14 @@ cd examples/novnc-browser/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -37,6 +43,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/novnc-browser:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=4000,stateful=true --metro fra -p 443:6080/tls+http -m 4G --image <my-org>/novnc-browser:latest
@@ -44,6 +51,7 @@ unikraft run --scale-to-zero policy=on,cooldown-time=4000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy \
     --scale-to-zero on \
@@ -57,23 +65,7 @@ kraft cloud deploy \
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: vnc-browser
- ├───────── uuid: 90a59b05-0ae1-4ca6-8383-79c5115355ee
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://weathered-fog-y5jjmwfd.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/novnc-browser@sha256:fdb4887e84362ebbaf54c713e0d85f547e8ee173fe63a6ab39e94b7e612a9892
- ├─────── memory: 4096 MiB
- ├────── service: weathered-fog-y5jjmwfd
- ├─ private fqdn: vnc-browser.internal
- └─── private ip: 10.0.0.49
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         vnc-browser
@@ -96,6 +88,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: vnc-browser
+ ├───────── uuid: 90a59b05-0ae1-4ca6-8383-79c5115355ee
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://weathered-fog-y5jjmwfd.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/novnc-browser@sha256:fdb4887e84362ebbaf54c713e0d85f547e8ee173fe63a6ab39e94b7e612a9892
+ ├─────── memory: 4096 MiB
+ ├────── service: weathered-fog-y5jjmwfd
+ ├─ private fqdn: vnc-browser.internal
+ └─── private ip: 10.0.0.49
+```
+
 In this case, the instance name is `vnc-browser` and the address is `https://weathered-fog-y5jjmwfd.fra.unikraft.app`.
 The name was preset, but the address is different for each run.
 Enter the provided address into your browser of choice to access the remote desktop interface.
@@ -112,6 +122,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -123,6 +134,7 @@ fra    vnc-browser  standby  <my-org>/novnc-browser        4.0GiB  1      weathe
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -134,12 +146,14 @@ vnc-browser  weathered-fog-y5jjmwfd.fra.unikraft.app  standby  standby  oci://un
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete vnc-browser
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove vnc-browser
 ```
@@ -148,12 +162,14 @@ kraft cloud instance remove vnc-browser
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -11,6 +11,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/opentelemetry-collector/` directory:
 
 ```bash
@@ -21,12 +25,14 @@ cd examples/opentelemetry-collector/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -36,6 +42,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/opentelemetry-collector:latest
 unikraft run --metro fra -m 1536M --image <my-org>/opentelemetry-collector:latest
@@ -43,27 +50,14 @@ unikraft run --metro fra -m 1536M --image <my-org>/opentelemetry-collector:lates
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy -M 1536Mi .
 ```
 
 The output shows the instance details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: opentelemetry-collector-bvtnh
- ├───────── uuid: 40e8b154-b3b6-4312-ae69-2cdb794b15e4
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├──────── image: oci://unikraft.io/<my-org>/opentelemetry-collector@sha256:64f73ea5fe208f54e5212f57979f24bebcf36276495462c52b380d15dd539ced
- ├─────── memory: 1536 MiB
- ├─ private fqdn: opentelemetry-collector-bvtnh.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         opentelemetry-collector-bvtnh
@@ -81,6 +75,22 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: opentelemetry-collector-bvtnh
+ ├───────── uuid: 40e8b154-b3b6-4312-ae69-2cdb794b15e4
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├──────── image: oci://unikraft.io/<my-org>/opentelemetry-collector@sha256:64f73ea5fe208f54e5212f57979f24bebcf36276495462c52b380d15dd539ced
+ ├─────── memory: 1536 MiB
+ ├─ private fqdn: opentelemetry-collector-bvtnh.internal
+ └─── private ip: 10.0.3.3
+```
+
 In this case, the instance name is `opentelemetry-collector-bvtnh`.
 They're different for each run.
 
@@ -92,6 +102,7 @@ Feel free to change and redeploy!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -103,6 +114,7 @@ fra    opentelemetry-collector-bvtnh  running  <my-org>/opentelemetry        153
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -114,12 +126,14 @@ opentelemetry-collector-bvtnh        running  since 11mins  oci://unikraft.io/<m
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete opentelemetry-collector-bvtnh
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove opentelemetry-collector-bvtnh
 ```
@@ -135,12 +149,14 @@ Such as adding another export, apart from the debug exporter.
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -9,6 +9,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/postgres/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/postgres/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/postgres:latest
 unikraft run --metro fra --scale-to-zero policy=idle,cooldown-time=1000,stateful=true -p 5432:5432/tls -m 1G -e POSTGRES_PASSWORD=unikraft --image <my-org>/postgres:latest
@@ -41,29 +48,14 @@ unikraft run --metro fra --scale-to-zero policy=idle,cooldown-time=1000,stateful
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 5432:5432/tls -M 1Gi -e POSTGRES_PASSWORD=unikraft .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: postgres-saan9
- ├───────── uuid: 3a1371f2-68c6-4187-84f8-c080f2b028ca
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://young-thunder-fbafrsxj.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/postgres@sha256:2476c0373d663d7604def7c35ffcb4ed4de8ab231309b4f20104b84f31570766
- ├─────── memory: 1024 MiB
- ├────── service: young-thunder-fbafrsxj
- ├─ private fqdn: postgres-saan9.internal
- └─── private ip: 10.0.3.1
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         postgres-saan9
@@ -84,6 +76,24 @@ networks:
   mac:        12:b0:31:34:b1:96
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: postgres-saan9
+ ├───────── uuid: 3a1371f2-68c6-4187-84f8-c080f2b028ca
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://young-thunder-fbafrsxj.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/postgres@sha256:2476c0373d663d7604def7c35ffcb4ed4de8ab231309b4f20104b84f31570766
+ ├─────── memory: 1024 MiB
+ ├────── service: young-thunder-fbafrsxj
+ ├─ private fqdn: postgres-saan9.internal
+ └─── private ip: 10.0.3.1
 ```
 
 In this case, the instance name is `postgres-saan9` and the service `young-thunder-fbafrsxj`.
@@ -126,6 +136,7 @@ Use SQL and `psql` commands for your work.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -137,6 +148,7 @@ fra    postgres-saan9  running  <my-org>/postgres        1.0GiB  1      young-th
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -148,12 +160,14 @@ postgres-saan9  young-thunder-fbafrsxj.fra.unikraft.app  running  6 minutes ago 
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instance remove postgres-saan9
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove postgres-saan9
 ```
@@ -163,18 +177,21 @@ kraft cloud instance remove postgres-saan9
 You can use [volumes](https://unikraft.com/docs/platform/volumes) for data persistence for your PostgreSQL instance.
 For that you would first create a volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume create --set metro=fra --set name=postgres --set size=200M
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume create --name postgres --size 200Mi
 ```
 
 Then start the PostgreSQL instance and mount that volume:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/postgres:latest
 unikraft run --metro fra --scale-to-zero policy=idle,cooldown-time=1000,stateful=true -p 5432:5432/tls -m 1G -e POSTGRES_PASSWORD=unikraft -e PGDATA=/volume/postgres --volume postgres:/volume --image <my-org>/postgres:latest
@@ -182,6 +199,7 @@ unikraft run --metro fra --scale-to-zero policy=idle,cooldown-time=1000,stateful
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 5432:5432/tls -M 1Gi -e POSTGRES_PASSWORD=unikraft -e PGDATA=/volume/postgres -v postgres:/volume .
 ```
@@ -206,12 +224,14 @@ But in that case make sure to disable scale-to-zero if you plan to use the DB in
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/python-playwright-chromium/README.md
+++ b/python-playwright-chromium/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/python-playwright-chromium/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/python-playwright-chromium/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/python-playwright-chromium:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:8080/tls+http -m 4G --image <my-org>/python-playwright-chromium:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: python-playwright-chromium-m6k3p
- ├───────── uuid: e6f7a8b9-c0d1-2e3f-4a5b-e6f7a8b9c0d1
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://young-night-kq8bv2mx.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/python-playwright-chromium@sha256:3c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d
- ├─────── memory: 4096 MiB
- ├────── service: young-night-kq8bv2mx
- ├─ private fqdn: python-playwright-chromium-m6k3p.internal
- └─── private ip: 10.0.6.5
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         python-playwright-chromium-m6k3p
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: python-playwright-chromium-m6k3p
+ ├───────── uuid: e6f7a8b9-c0d1-2e3f-4a5b-e6f7a8b9c0d1
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://young-night-kq8bv2mx.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/python-playwright-chromium@sha256:3c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d
+ ├─────── memory: 4096 MiB
+ ├────── service: young-night-kq8bv2mx
+ ├─ private fqdn: python-playwright-chromium-m6k3p.internal
+ └─── private ip: 10.0.6.5
+```
+
 In this case, the instance name is `python-playwright-chromium-m6k3p` and the address is `https://young-night-kq8bv2mx.fra.unikraft.app`.
 They're different for each run.
 
@@ -102,6 +112,7 @@ curl "https://<NAME>.<METRO>.unikraft.app/?page=https://github.com" -o ss-github
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -113,6 +124,7 @@ fra    python-playwright-chromium-m6k3p  running  <my-org>/python-playwright-chr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -124,12 +136,14 @@ python-playwright-chromium-m6k3p  young-night-kq8bv2mx.fra.unikraft.app  running
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete <instance-name>
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove <instance-name>
 ```
@@ -145,12 +159,14 @@ kraft cloud instance remove <instance-name>
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/redis7.2/README.md
+++ b/redis7.2/README.md
@@ -9,6 +9,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/redis7.2/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/redis7.2/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/redis72:latest
 unikraft run --scale-to-zero policy=off --metro fra -p 6379:6379/tls -m 512M --image <my-org>/redis72:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=off --metro fra -p 6379:6379/tls -m 512M --i
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero off -p 6379:6379/tls -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: redis72-alb4r
- ├───────── uuid: d3c3141b-97b2-4e1d-87ae-39e4f14ab49e
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://rough-wind-8vxrd1ms.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/redis72@sha256:9665c51faf7deb538cf7907b012b55700cad08cd391f5ba099d95d018c8da7d
- ├─────── memory: 512 MiB
- ├────── service: rough-wind-8vxrd1ms
- ├─ private fqdn: redis72-alb4r.internal
- └─── private ip: 10.0.3.2
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         redis72-alb4r
@@ -84,6 +76,24 @@ networks:
   mac:        12:b0:4e:20:b3:e7
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: redis72-alb4r
+ ├───────── uuid: d3c3141b-97b2-4e1d-87ae-39e4f14ab49e
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://rough-wind-8vxrd1ms.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/redis72@sha256:9665c51faf7deb538cf7907b012b55700cad08cd391f5ba099d95d018c8da7d
+ ├─────── memory: 512 MiB
+ ├────── service: rough-wind-8vxrd1ms
+ ├─ private fqdn: redis72-alb4r.internal
+ └─── private ip: 10.0.3.2
 ```
 
 In this case, the instance name is `redis72-alb4r` which is different for every run.
@@ -134,6 +144,7 @@ To disconnect, kill the `socat` command with ctrl-C.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -145,6 +156,7 @@ fra    redis72-alb4r  running  <my-org>/redis72        512MiB  1      rough-wind
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -156,12 +168,14 @@ redis72-alb4r  rough-wind-8vxrd1ms.fra.unikraft.app  running  1 minute ago  oci:
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete redis72-alb4r
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove redis72-alb4r
 ```
@@ -177,12 +191,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/ruby3.2-rails/README.md
+++ b/ruby3.2-rails/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/ruby3.2-rails/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/ruby3.2-rails/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/ruby32-rails:latest
 unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 1G -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle --image <my-org>/ruby32-rails:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=idle,cooldown-time=1000,stateful=true --metr
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero idle --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 1Gi -e GEM_HOME=/usr/local/bundle -e BUNDLE_APP_CONFIG=/usr/local/bundle .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: ruby32-rails-apa93
- ├───────── uuid: 2f85b9db-94f8-45d2-8e38-ed9b56cb8695
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://aged-waterfall-qraz0s7d.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/ruby32-rails@sha256:fdd46011408fdee05644665ad59b24115737e3fdb352169ec2f3f16a45d4f31d
- ├─────── memory: 1024 MiB
- ├────── service: aged-waterfall-qraz0s7d
- ├─ private fqdn: ruby32-rails-apa93.internal
- └─── private ip: 10.0.3.3
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         ruby32-rails-apa93
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:39:3e:b5:36
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: ruby32-rails-apa93
+ ├───────── uuid: 2f85b9db-94f8-45d2-8e38-ed9b56cb8695
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://aged-waterfall-qraz0s7d.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/ruby32-rails@sha256:fdd46011408fdee05644665ad59b24115737e3fdb352169ec2f3f16a45d4f31d
+ ├─────── memory: 1024 MiB
+ ├────── service: aged-waterfall-qraz0s7d
+ ├─ private fqdn: ruby32-rails-apa93.internal
+ └─── private ip: 10.0.3.3
 ```
 
 In this case, the instance name is `ruby32-rails-apa93` and the address is `https://aged-waterfall-qraz0s7d.fra.unikraft.app`.
@@ -106,6 +116,7 @@ Hello, World!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -117,6 +128,7 @@ fra    ruby32-rails-apa93  running  <my-org>/ruby32-rails        1.0GiB  1      
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -128,12 +140,14 @@ ruby32-rails-apa93  aged-waterfall-qraz0s7d.fra.unikraft.app  running  2 minutes
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete ruby32-rails-apa93
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove ruby32-rails-apa93
 ```
@@ -204,12 +218,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/skipper0.18/README.md
+++ b/skipper0.18/README.md
@@ -9,6 +9,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/skipper0.18/` directory:
 
 ```bash
@@ -19,12 +23,14 @@ cd examples/skipper0.18/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +40,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/skipper018:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:9090/tls+http -m 256M --image <my-org>/skipper018:latest
@@ -41,29 +48,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:9090/tls+http -M 256Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: skipper018-mx4ai
- ├───────── uuid: 34e3d740-c2b0-4644-b7e1-647350f688dc
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://aged-sea-o7d3c42s.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/skipper018@sha256:5483eaf3612cca2116ceaab9be42557686324f1d30337ae15d0495eef63d0386
- ├─────── memory: 256 MiB
- ├────── service: aged-sea-o7d3c42s
- ├─ private fqdn: skipper018-mx4ai.internal
- └─── private ip: 10.0.6.4
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         skipper018-mx4ai
@@ -86,6 +78,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: skipper018-mx4ai
+ ├───────── uuid: 34e3d740-c2b0-4644-b7e1-647350f688dc
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://aged-sea-o7d3c42s.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/skipper018@sha256:5483eaf3612cca2116ceaab9be42557686324f1d30337ae15d0495eef63d0386
+ ├─────── memory: 256 MiB
+ ├────── service: aged-sea-o7d3c42s
+ ├─ private fqdn: skipper018-mx4ai.internal
+ └─── private ip: 10.0.6.4
+```
+
 In this case, the instance name is `skipper018-mx4ai` and the address is `https://aged-sea-o7d3c42s.fra.unikraft.app`.
 They're different for each run.
 
@@ -101,6 +111,7 @@ Hello, world from Skipper on Unikraft!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -112,6 +123,7 @@ fra    skipper018-mx4ai  running  <my-org>/skipper018        256MiB  1      aged
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -123,12 +135,14 @@ skipper018-mx4ai  aged-sea-o7d3c42s.fra.unikraft.app  running  1 minute ago  oci
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete skipper018-mx4ai
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove skipper018-mx4ai
 ```
@@ -141,12 +155,14 @@ To customize Skipper you can change the `example.eskip` configuration file.
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/spin-wagi-http/README.md
+++ b/spin-wagi-http/README.md
@@ -11,6 +11,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/spin-wagi-http/` directory:
 
 ```bash
@@ -21,12 +25,14 @@ cd examples/spin-wagi-http/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -36,6 +42,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/spin-wagi-http:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:3000/tls+http -m 4G --image <my-org>/spin-wagi-http:latest
@@ -43,29 +50,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:3000/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: spin-wagi-http-is72r
- ├───────── uuid: 045c1bda-0f2e-4f8b-98c7-a208bfa7d143
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://damp-bobo-wg43p36e.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/spin-wagi-http@sha256:57a5151996d83332af6da521e1cd92271a8c3ac7ae26bc44a7c0dbbc0a30e577
- ├─────── memory: 4096 MiB
- ├────── service: damp-bobo-wg43p36e
- ├─ private fqdn: spin-wagi-http-is72r.internal
- └─── private ip: 10.0.28.16
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         spin-wagi-http-is72r
@@ -86,6 +78,24 @@ networks:
   mac:        12:b0:fc:f5:09:d5
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: spin-wagi-http-is72r
+ ├───────── uuid: 045c1bda-0f2e-4f8b-98c7-a208bfa7d143
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://damp-bobo-wg43p36e.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/spin-wagi-http@sha256:57a5151996d83332af6da521e1cd92271a8c3ac7ae26bc44a7c0dbbc0a30e577
+ ├─────── memory: 4096 MiB
+ ├────── service: damp-bobo-wg43p36e
+ ├─ private fqdn: spin-wagi-http-is72r.internal
+ └─── private ip: 10.0.28.16
 ```
 
 In this case, the instance name is `spin-wagi-http-is72r` and the address is `https://damp-bobo-wg43p36e.fra.unikraft.app`.
@@ -109,6 +119,7 @@ Goodbye, Fermyon!
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -120,6 +131,7 @@ fra    spin-wagi-http-is72r  running  <my-org>/spin-wagi-http        4.0GiB  1  
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -131,12 +143,14 @@ spin-wagi-http-is72r  damp-bobo-wg43p36e.fra.unikraft.app  running  1 minute ago
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete spin-wagi-http-is72r
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove spin-wagi-http-is72r
 ```
@@ -175,12 +189,14 @@ The following options are available for customizing the app:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/traefik/README.md
+++ b/traefik/README.md
@@ -8,6 +8,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/traefik/` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/traefik/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/traefik:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro fra -p 443:80/tls+http -p 8080:8080/tls -m 1G --image <my-org>/traefik:latest
@@ -40,29 +47,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 1s -p 443:80/tls+http -p 8080:8080/tls -M 1Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: traefik-wqe7e
- ├───────── uuid: 69d25b0b-1813-4a3f-88e6-64abbc78b359
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://holy-cherry-rye39b1x.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/traefik@sha256:f6dd913a81f6a057ceb9db7844222d7287b2a83f668cca88c73c2e85554cb526
- ├─────── memory: 1024 MiB
- ├────── service: holy-cherry-rye39b1x
- ├─ private fqdn: traefik-wqe7e.internal
- └─── private ip: 10.0.28.16
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         traefik-wqe7e
@@ -83,6 +75,24 @@ networks:
   mac:        12:b0:31:58:d7:d0
 timestamps:
   created:    just now
+```
+
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: traefik-wqe7e
+ ├───────── uuid: 69d25b0b-1813-4a3f-88e6-64abbc78b359
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://holy-cherry-rye39b1x.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/traefik@sha256:f6dd913a81f6a057ceb9db7844222d7287b2a83f668cca88c73c2e85554cb526
+ ├─────── memory: 1024 MiB
+ ├────── service: holy-cherry-rye39b1x
+ ├─ private fqdn: traefik-wqe7e.internal
+ └─── private ip: 10.0.28.16
 ```
 
 In this case, the instance name is `traefik-wqe7e` and the address is `https://holy-cherry-rye39b1x.fra.unikraft.app`.
@@ -106,6 +116,7 @@ Or better yet, point a browser at the dashboard.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -117,6 +128,7 @@ fra    traefik-wqe7e  running  <my-org>/traefik        1024MiB  1      holy-cher
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -128,12 +140,14 @@ traefik-wqe7e  holy-cherry-rye39b1x.fra.unikraft.app  running  8 minutes ago  oc
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete traefik-wqe7e
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove traefik-wqe7e
 ```
@@ -146,12 +160,14 @@ To customize Traefik app you can change the `default.toml` configuration file.
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/tyk/README.md
+++ b/tyk/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/tyk/` directory:
 
 ```bash

--- a/visual-studio-code-server/README.md
+++ b/visual-studio-code-server/README.md
@@ -12,6 +12,10 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/visual-studio-code-server` directory:
 
 ```bash
@@ -22,12 +26,14 @@ cd examples/visual-studio-code-server/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -37,6 +43,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume create --set metro=fra --set name=code-workspace --set size=1G
 
@@ -46,6 +53,7 @@ unikraft run --metro fra -p 443:8443/tls+http -m 2G --volume code-workspace:/wor
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume create --name code-workspace --size 1Gi
 
@@ -54,23 +62,7 @@ kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-c
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: code-server
- ├───────── uuid: c1a619a0-e222-4042-94b8-ba4b39353417
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://blue-shape-chmxf1g4.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/visual-studio-code-server@sha256:633ec8a8dcb342b093c6f055f84fc056ee1abe40ff56e98bd612c4b9d4ddffcb
- ├─────── memory: 2048 MiB
- ├────── service: blue-shape-chmxf1g4
- ├─ private fqdn: code-server.internal
- └─── private ip: 10.0.0.49
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         code-server
@@ -93,6 +85,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: code-server
+ ├───────── uuid: c1a619a0-e222-4042-94b8-ba4b39353417
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://blue-shape-chmxf1g4.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/visual-studio-code-server@sha256:633ec8a8dcb342b093c6f055f84fc056ee1abe40ff56e98bd612c4b9d4ddffcb
+ ├─────── memory: 2048 MiB
+ ├────── service: blue-shape-chmxf1g4
+ ├─ private fqdn: code-server.internal
+ └─── private ip: 10.0.0.49
+```
+
 This will create a volume for data persistence, and mount it at `/workspace` inside the VM.
 
 In this case, the instance name is `code-server` and the address is `https://blue-shape-chmxf1g4.fra.unikraft.app`.
@@ -101,10 +111,12 @@ Enter the provided address into your browser of choice to access the Code server
 
 You can list information about the volume by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volumes list
 ```
 
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 METRO  NAME            STATE    SIZE    CREATED
 fra    code-workspace  mounted  1.0GiB  13 minutes ago
@@ -112,10 +124,12 @@ fra    code-workspace  mounted  1.0GiB  13 minutes ago
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume list
 ```
 
+**Using the legacy kraft CLI**
 ```ansi title="kraft"
 NAME            CREATED AT      SIZE     ATTACHED TO  MOUNTED BY   STATE      PERSISTENT
 code-workspace  13 minutes ago  1.0 GiB  code-server  code-server  mounted    true
@@ -123,6 +137,7 @@ code-workspace  13 minutes ago  1.0 GiB  code-server  code-server  mounted    tr
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -134,6 +149,7 @@ fra    code-server  standby  <my-org>/visual-studio-code-server        2.0GiB  1
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -145,12 +161,14 @@ code-server  blue-shape-chmxf1g4.fra.unikraft.app  standby  standby  oci://unikr
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete code-server
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove code-server
 ```
@@ -158,12 +176,14 @@ kraft cloud instance remove code-server
 The volume isn't removed by default, so you can recreate the instance and still have access to your old data.
 Remove it using:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume delete code-workspace
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume remove code-workspace
 ```
@@ -172,12 +192,14 @@ kraft cloud volume remove code-workspace
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/vsftpd/README.md
+++ b/vsftpd/README.md
@@ -8,6 +8,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/vsftpd` directory:
 
 ```bash
@@ -18,12 +22,14 @@ cd examples/vsftpd/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -33,6 +39,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume create --set metro=fra --set name=vsftpd-workspace --set size=1G
 
@@ -42,6 +49,7 @@ unikraft run --metro fra --scale-to-zero policy=on,cooldown-time=40000,stateful=
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume create --name vsftpd-workspace --size 1Gi
 
@@ -50,23 +58,7 @@ kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-c
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: vsftpd
- ├───────── uuid: 186a46a0-7c89-4bfd-83a8-649bcc60a96e
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://broken-orangutan-jypu2z53.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/vsftpd@sha256:31aad1619c31f499b11f1bef8fead6e6df76f235a57add011e5e414a3f51ee64
- ├─────── memory: 1024 MiB
- ├────── service: broken-orangutan-jypu2z53
- ├─ private fqdn: vsftpd.internal
- └─── private ip: 10.0.0.109
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         vsftpd
@@ -89,6 +81,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: vsftpd
+ ├───────── uuid: 186a46a0-7c89-4bfd-83a8-649bcc60a96e
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://broken-orangutan-jypu2z53.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/vsftpd@sha256:31aad1619c31f499b11f1bef8fead6e6df76f235a57add011e5e414a3f51ee64
+ ├─────── memory: 1024 MiB
+ ├────── service: broken-orangutan-jypu2z53
+ ├─ private fqdn: vsftpd.internal
+ └─── private ip: 10.0.0.109
+```
+
 This will create a volume for data persistence, and mount it at `/root` inside the VM.
 
 In this case, the instance name is `vsftpd` and the address is `https://broken-orangutan-jypu2z53.fra.unikraft.app`.
@@ -106,10 +116,12 @@ lftp root@broken-orangutan-jypu2z53.fra.unikraft.app:~> ls
 
 You can list information about the volume by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volumes list
 ```
 
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 METRO  NAME              STATE    SIZE    CREATED
 fra    vsftpd-workspace  mounted  1.0GiB  9 minutes ago
@@ -117,10 +129,12 @@ fra    vsftpd-workspace  mounted  1.0GiB  9 minutes ago
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume list
 ```
 
+**Using the legacy kraft CLI**
 ```ansi title="kraft"
 NAME              CREATED AT     SIZE     ATTACHED TO  MOUNTED BY  STATE    PERSISTENT
 vsftpd-workspace  9 minutes ago  1.0 GiB  vsftpd       vsftpd      mounted  true
@@ -128,6 +142,7 @@ vsftpd-workspace  9 minutes ago  1.0 GiB  vsftpd       vsftpd      mounted  true
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -139,6 +154,7 @@ fra    vsftpd  standby  <my-org>/vsftpd        1.0GiB  1      broken-orangutan-j
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -150,12 +166,14 @@ vsftpd  broken-orangutan-jypu2z53.fra.unikraft.app  standby  standby  oci://unik
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete vsftpd
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove vsftpd
 ```
@@ -163,12 +181,14 @@ kraft cloud instance remove vsftpd
 The volume isn't removed by default, so you can recreate the instance and still have access to your old data.
 Remove it using:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft volume delete vsftpd-workspace
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud volume remove vsftpd-workspace
 ```
@@ -177,12 +197,14 @@ kraft cloud volume remove vsftpd-workspace
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/wazero-import-go/README.md
+++ b/wazero-import-go/README.md
@@ -10,6 +10,10 @@ To run this example, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/wazero-import-go/` directory:
 
 ```bash
@@ -20,12 +24,14 @@ cd examples/wazero-import-go/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -35,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/wazero-import-go:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:8080/tls+http -m 512M --image <my-org>/wazero-import-go:latest
@@ -42,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=1000 --metro fra -p 443:808
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-cooldown 1s -p 443:8080/tls+http -M 512Mi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: wazero-import-go-r4dx8
- ├───────── uuid: a763e1c3-bb38-475f-95b6-1e78d8ca74fc
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://cool-morning-camrrhsa.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/wazero-import-go@sha256:865700d358ffb2751888798ec8f302d23310b1fcf84f4d3f17f79fc25ff71153
- ├─────── memory: 512 MiB
- ├────── service: cool-morning-camrrhsa
- ├─ private fqdn: wazero-import-go-r4dx8.internal
- └─── private ip: 10.0.6.7
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         wazero-import-go-r4dx8
@@ -87,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: wazero-import-go-r4dx8
+ ├───────── uuid: a763e1c3-bb38-475f-95b6-1e78d8ca74fc
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://cool-morning-camrrhsa.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/wazero-import-go@sha256:865700d358ffb2751888798ec8f302d23310b1fcf84f4d3f17f79fc25ff71153
+ ├─────── memory: 512 MiB
+ ├────── service: cool-morning-camrrhsa
+ ├─ private fqdn: wazero-import-go-r4dx8.internal
+ └─── private ip: 10.0.6.7
+```
+
 In this case, the instance name is `wazero-import-go-r4dx8` and the address is `https://cool-morning-camrrhsa.fra.unikraft.app`.
 They're different for each run.
 
@@ -103,6 +113,7 @@ log_i32 >> 24
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -114,6 +125,7 @@ fra    wazero-import-go-r4dx8  running  <my-org>/wazero-import-go        512MiB 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -125,12 +137,14 @@ wazero-import-go-r4dx8  cool-morning-camrrhsa.fra.unikraft.app  running  1 minut
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete wazero-import-go-r4dx8
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove wazero-import-go-r4dx8
 ```
@@ -164,12 +178,14 @@ To customize the app, update the files in the repository, listed below:
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```

--- a/wordpress-all-in-one/README.md
+++ b/wordpress-all-in-one/README.md
@@ -9,6 +9,11 @@ To run it, follow these steps:
    You need a [BuildKit](https://github.com/moby/buildkit) builder. The easiest way to get one is via [Docker](https://docs.docker.com/engine/install/).
    Alternatively, you can also directly set up and use BuildKit, see the [quick start](https://github.com/moby/buildkit#quick-start).
 
+> **Note**:
+> The unikraft CLI is the current standard, while kraft is the legacy version.
+> Choose one of the CLIs below and only run the commands associated with it for the rest of this guide.
+
+
 2. Clone the [`examples` repository](https://github.com/unikraft-cloud/examples) and `cd` into the `examples/wordpress-all-in-one/` directory:
 
 ```bash
@@ -19,12 +24,14 @@ cd examples/wordpress-all-in-one/
 Make sure to log into Unikraft Cloud and pick a [metro](https://unikraft.com/docs/platform/metros) close to you.
 This guide uses `fra` (Frankfurt, 🇩🇪):
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft login
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 # Set Unikraft Cloud access token
 export UKC_TOKEN=token
@@ -34,6 +41,7 @@ export UKC_METRO=fra
 
 When done, invoke the following command to deploy this app on Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft build . --output <my-org>/wordpress-all-in-one:latest
 unikraft run --scale-to-zero policy=on,cooldown-time=3000,stateful=true --metro fra -p 443:3000/tls+http -m 4G --image <my-org>/wordpress-all-in-one:latest
@@ -41,29 +49,14 @@ unikraft run --scale-to-zero policy=on,cooldown-time=3000,stateful=true --metro 
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud deploy --scale-to-zero on --scale-to-zero-stateful --scale-to-zero-cooldown 3s -p 443:3000/tls+http -M 4Gi .
 ```
 
 The output shows the instance address and other details:
 
-```ansi title="kraft"
-[●] Deployed successfully!
- │
- ├───────── name: wordpress-fx5rb
- ├───────── uuid: bfb9d151-1604-452a-b2e0-f737486744df
- ├──────── metro: https://api.fra.unikraft.cloud/v1
- ├──────── state: starting
- ├─────── domain: https://cool-silence-h5c1es4z.fra.unikraft.app
- ├──────── image: oci://unikraft.io/<my-org>/wordpress@sha256:3e116e6c74dd04e19d4062a14f8173974ba625179ace3c10a2c96546638c4cd8
- ├─────── memory: 4096 MiB
- ├────── service: cool-silence-h5c1es4z
- ├─ private fqdn: wordpress-fx5rb.internal
- └─── private ip: 10.0.3.1
-```
-
-or
-
+**Using the unikraft CLI (Recommended)**
 ```ansi title="unikraft"
 metro:        fra
 name:         wordpress-fx5rb
@@ -86,6 +79,24 @@ timestamps:
   created:    just now
 ```
 
+or
+
+**Using the legacy kraft CLI**
+```ansi title="kraft"
+[●] Deployed successfully!
+ │
+ ├───────── name: wordpress-fx5rb
+ ├───────── uuid: bfb9d151-1604-452a-b2e0-f737486744df
+ ├──────── metro: https://api.fra.unikraft.cloud/v1
+ ├──────── state: starting
+ ├─────── domain: https://cool-silence-h5c1es4z.fra.unikraft.app
+ ├──────── image: oci://unikraft.io/<my-org>/wordpress@sha256:3e116e6c74dd04e19d4062a14f8173974ba625179ace3c10a2c96546638c4cd8
+ ├─────── memory: 4096 MiB
+ ├────── service: cool-silence-h5c1es4z
+ ├─ private fqdn: wordpress-fx5rb.internal
+ └─── private ip: 10.0.3.1
+```
+
 In this case, the instance name is `wordpress-fx5rb`.
 They're different for each run.
 
@@ -94,6 +105,7 @@ Fill out the form and complete the Wordpress install.
 
 You can list information about the instance by running:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances list
 ```
@@ -105,6 +117,7 @@ fra    wordpress-fx5rb  running  <my-org>/wordpress-all-in-one        4096MiB  1
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance list
 ```
@@ -116,12 +129,14 @@ wordpress-fx5rb  cool-silence-h5c1es4z.fra.unikraft.app  running  1 minute ago  
 
 When done, you can remove the instance:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft instances delete wordpress-fx5rb
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud instance remove wordpress-fx5rb
 ```
@@ -130,12 +145,14 @@ kraft cloud instance remove wordpress-fx5rb
 
 Use the `--help` option for detailed information on using Unikraft Cloud:
 
+**Using the unikraft CLI (Recommended)**
 ```bash title="unikraft"
 unikraft --help
 ```
 
 or
 
+**Using the legacy kraft CLI**
 ```bash title="kraft"
 kraft cloud --help
 ```


### PR DESCRIPTION
Updated the readmes to make sure that `unikraft` and `kraftkit` commands are used exclusively

- added note after the installation instruction
- on top of each code block there is a label that makes it clear which cli is being used
- made the order of the deploy command consistent with the others (unikraft first then kraftkit)