### PR TITLE
fix(httpserver-node21-solid-start): Pin compatible pnpm version

### DIFF
--- a/httpserver-node21-solid-start/Dockerfile
+++ b/httpserver-node21-solid-start/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src
 COPY . /usr/src/
 
 RUN set -xe && \
-    npm instal -g pnpm && \
+    npm install -g pnpm@9 && \
     pnpm install && \
     pnpm build
 


### PR DESCRIPTION
This prevents trying to install a newer pnpm version which requires node > 21, which would cause this node 21 based example to fail

Closes: FIELD-433