### PR TITLE
chore: Fix dependabot alerts for httpserver-node21-nextjs example

### DIFF
--- a/httpserver-node21-nextjs/package.json
+++ b/httpserver-node21-nextjs/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^19",
     "react-dom": "^19",
-    "next": ">=15.5.15"
+    "next": ">=15.5.18"
   },
   "devDependencies": {
     "typescript": "^5",
@@ -22,6 +22,6 @@
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "eslint": "^9",
-    "eslint-config-next": ">=15.5.15"
+    "eslint-config-next": ">=15.5.18"
   }
 }


### PR DESCRIPTION
Closes: FIELD-438