### PR TITLE
chore: Log generic error message

### DIFF
--- a/python-playwright-chromium/main.py
+++ b/python-playwright-chromium/main.py
@@ -20,5 +20,5 @@ async def screenshot_page(page: str | None = None):
         await playwright.stop()
 
         return Response(content=buffer, media_type="image/png")
-    except Exception as err:
-        return {"message": "An error occured: " + str(err)}
+    except Exception:
+        return {"message": "An internal error has occurred"}


### PR DESCRIPTION
The previous log unconditionally printed the Exception, which may contain sensitive information.

Closes: FIELD-439