### PR TITLE
chore(httpserver-node-vite-vanilla): Build rootfs from scratch layer

### DIFF
--- a/httpserver-node-vite-vanilla/.dockerignore
+++ b/httpserver-node-vite-vanilla/.dockerignore
@@ -1,2 +1,9 @@
 node_modules
 .unikraft/
+__pycache__
+.gitignore
+.dockerignore
+Dockerfile
+Kraftfile
+README.md
+*.py

--- a/httpserver-node-vite-vanilla/Dockerfile
+++ b/httpserver-node-vite-vanilla/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23 AS build
+FROM --platform=linux/x86_64 node:23-alpine AS build
 
 WORKDIR /app
 
@@ -7,4 +7,19 @@ COPY package*.json /app/
 RUN set -xe; \
     npm ci
 
-COPY . /app/
+COPY index.html vite.config.js /app/
+COPY src/ /app/src/
+COPY public/ /app/public/
+
+FROM scratch
+
+# Node binary
+COPY --from=build /usr/local/bin/node /usr/local/bin/node
+
+# System libraries
+COPY --from=build /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=build /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=build /usr/lib/libstdc++.so.6 /usr/lib/libstdc++.so.6
+
+# Application
+COPY --from=build /app /app

--- a/httpserver-node-vite-vanilla/Kraftfile
+++ b/httpserver-node-vite-vanilla/Kraftfile
@@ -6,4 +6,4 @@ rootfs:
   source: ./Dockerfile
   format: erofs
 
-cmd: ["npm", "run", "dev"]
+cmd: ["/usr/local/bin/node", "/app/node_modules/vite/bin/vite.js", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This reduces the rootfs size by not including unnecessary components from the node layer

Closes: FIELD-457