### PR TITLE
chore: Optimise build for Hugo example

### DIFF
--- a/hugo0.122/Dockerfile
+++ b/hugo0.122/Dockerfile
@@ -1,29 +1,18 @@
-FROM golang:1.23.3-bookworm AS build
+FROM debian:bookworm-slim AS build
 
-ARG HUGO_VERSION=v0.146.0
-
-WORKDIR /src
+ARG HUGO_VERSION=0.146.0
 
 RUN set -xe; \
-    CGO_ENABLED=1 \
-    go install \
-      -buildmode=pie \
-      -tags extended \
-      github.com/gohugoio/hugo@${HUGO_VERSION} \
-    ;
-
-WORKDIR /site
-
-RUN set -xe; \
-    hugo new site .; \
-    git clone --depth 1 https://github.com/budparr/gohugo-theme-ananke.git themes/ananke; \
-    echo 'theme = "ananke"' >> hugo.toml \
-    ;
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin hugo; \
+    rm -rf /var/lib/apt/lists/*
 
 FROM scratch
 
 # Binary executable
-COPY --from=build /go/bin/hugo /usr/bin/hugo
+COPY --from=build /usr/local/bin/hugo /usr/bin/hugo
 
 # System libraries
 COPY --from=build /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
@@ -33,5 +22,4 @@ COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/libg
 COPY --from=build /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
 
 # Site
-COPY --from=build /site /site
 COPY ./site /site


### PR DESCRIPTION
Its Pytest was prone to timing out.

To mitigate this, this commit:

 - Fetches a prebuilt binary instead of building Hugo from source
 - Copy the /site directory from the repo, instead of creating it from scratch

Closes: FIELD-463