### PR TITLE
fix(httpserver-node-express-puppeteer): fix base64 SSRF

### DIFF
--- a/httpserver-node-express-puppeteer/controller/generatePdf.js
+++ b/httpserver-node-express-puppeteer/controller/generatePdf.js
@@ -16,6 +16,14 @@ const generatePdf = async (type, payload) => {
   }
 
   if (type === 'base64') {
+    try {
+      if (Buffer.from(payload, 'base64').toString('base64') !== payload) {
+        throw new Error();
+      }
+    } catch {
+      await browser.close();
+      throw new Error("Invalid base64 content");
+    }
     const page = await browser.newPage();
     await page.goto(`data:text/html;base64,${payload}`);
     const pdf = await page.pdf();


### PR DESCRIPTION
Validate that the base64 payload contains only valid base64 characters before passing it to page.goto(). Without this, user-controlled input could inject arbitrary URL schemes into the data URI, enabling server-side request forgery.

Closes: FIELD-431