### PR TITLE
fix: Only run tests based off changes in PR

### DIFF
--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -93,8 +93,8 @@ jobs:
         else
           # For PRs and pushes to main, only test affected examples.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE=${{ github.event.pull_request.base.sha }}
             HEAD=${{ github.event.pull_request.head.sha }}
+            BASE=$(git merge-base "origin/${{ github.event.pull_request.base.ref }}" "$HEAD")
           else
             BASE=${{ github.event.before }}
             HEAD=${{ github.sha }}


### PR DESCRIPTION
Previously, if the source branch was out of date,
unrelated changes would be tested too.

Closes: FIELD-617