### PR TITLE
chore: Backup resource cleanup mechanism

### DIFF
--- a/.github/workflows/test-examples.yaml
+++ b/.github/workflows/test-examples.yaml
@@ -203,4 +203,12 @@ jobs:
         PY
 
     - name: Run tests
-      run: pytest --log-cli-level=INFO "${{ matrix.example }}"
+      env:
+        UKC_TEST_ID: ${{ github.run_id }}
+      run: exec pytest --log-cli-level=INFO "${{ matrix.example }}"
+
+    - name: Cleanup test resources
+      if: always()
+      env:
+        UKC_TEST_ID: ${{ github.run_id }}
+      run: bash scripts/cleanup-test-resources.sh

--- a/conftest.py
+++ b/conftest.py
@@ -75,12 +75,12 @@ def repo_root() -> Path:
 
 @pytest.fixture(scope="session")
 def test_run_id() -> str:
-    """Short random identifier unique to this pytest session.
+    """Identifier unique to this pytest session, taken from ``UKC_TEST_ID``.
 
-    Used to avoid collisions between concurrent CI runs when naming images
-    and instances.
+    Set ``UKC_TEST_ID`` to the CI run ID (e.g. ``${{ github.run_id }}``) so
+    that resources can be correlated and cleaned up after the run.
     """
-    return uuid.uuid4().hex[:8]
+    return _require_env("UKC_TEST_ID")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/cleanup-test-resources.sh
+++ b/scripts/cleanup-test-resources.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Deletes all Unikraft Cloud resources created during a test run.
+#
+# Usage:  UKC_TEST_ID=<run-id> UKC_METRO=<metro> ./scripts/cleanup-test-resources.sh
+#
+# The script is intentionally lenient: each deletion is attempted with --force
+# and failures are logged but do not abort the script, so a partial cleanup
+# never masks other resources.
+
+set -euo pipefail
+
+: "${UKC_TEST_ID:?UKC_TEST_ID must be set}"
+: "${UKC_METRO:?UKC_METRO must be set}"
+
+FILTER="name~=\"^.*${UKC_TEST_ID}\""
+
+echo "==> Cleaning up test resources for run ID: ${UKC_TEST_ID} (metro: ${UKC_METRO})"
+
+echo "--> Deleting instances..."
+unikraft instances delete \
+    --metro "${UKC_METRO}" \
+    --filter "${FILTER}" \
+    --force || echo "Warning: instance deletion failed or nothing to delete"
+
+echo "--> Deleting instance templates..."
+unikraft instances templates delete \
+    --metro "${UKC_METRO}" \
+    --filter "${FILTER}" \
+    --force || echo "Warning: instance template deletion failed or nothing to delete"
+
+echo "--> Deleting volumes..."
+unikraft volumes delete \
+    --metro "${UKC_METRO}" \
+    --filter "${FILTER}" \
+    --force || echo "Warning: volume deletion failed or nothing to delete"
+
+echo "--> Deleting images..."
+IMAGE_FILTER="ref~=\"^.*${UKC_TEST_ID}\""
+IMAGES=$(unikraft images list \
+    --metro "${UKC_METRO}" \
+    --filter "${IMAGE_FILTER}" \
+    --field ref \
+    --output raw 2>/dev/null \
+    | jq -r '.[].name' 2>/dev/null || true)
+
+if [[ -z "${IMAGES}" ]]; then
+    echo "    No images to delete."
+else
+    while IFS= read -r image; do
+        echo "    Deleting image: ${image}"
+        unikraft images delete "${image}" \
+            --metro "${UKC_METRO}" || echo "Warning: failed to delete image ${image}"
+    done <<< "${IMAGES}"
+fi
+
+echo "==> Cleanup complete."

--- a/visual-studio-code-server/test_visual-studio-code-server.py
+++ b/visual-studio-code-server/test_visual-studio-code-server.py
@@ -13,7 +13,6 @@ the existing CI workflow (example-visual-studio-code-server-stable.yaml):
 from __future__ import annotations
 
 import logging
-import uuid
 
 from _testlib.unikraft import extract_instance_name, extract_instance_url
 
@@ -21,11 +20,11 @@ log = logging.getLogger(__name__)
 
 
 def test_visual_studio_code_server(
-    request, build_image, run_instance, unikraft, http
-, wait_instance):
+    request, build_image, run_instance, unikraft, http, wait_instance, test_run_id
+):
     """Build, deploy, and verify the VS Code Server login page loads."""
     # Create a volume for workspace persistence, matching the old workflow.
-    vol_name = f"code-workspace-pytest-{uuid.uuid4().hex[:8]}"
+    vol_name = f"code-workspace-pytest-{test_run_id}"
     unikraft.run([
         "volume", "create",
         "--set", f"name={vol_name}",


### PR DESCRIPTION
This will avoid leaking resources in the case where a run is aborted.

Use the github run ID in the resource names
so they can be identified.

Invoke pytest with "exec pytest..." so the signal
gets sent to the pytest process, not the bash process

Closes: FIELD-625