### PR TITLE
fix: Remove outdated Unikraft Cloud skill from the OpenClaw example

### DIFF
--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update -y \
         openssh-server vim jq rsync \
     && rm -rf /var/lib/apt/lists/*
 
-# Install OpenClaw and the Unikraft Sandbox skill for OpenClaw
+# Install OpenClaw
 RUN npm i -g openclaw
-RUN openclaw skills install unikraft-sandbox
 
 COPY ./entrypoint.sh /usr/bin/entrypoint.sh


### PR DESCRIPTION
The outdated Unikraft Cloud Skill results in a build failure. We do not use this skill in the example anywhere. This PR removes the skill. The example itself remains entirely identical before and after this change.